### PR TITLE
Add prebuilt silhouette asset pipeline and homepage UI/loader improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,10 @@ ui-snapshots/
 *.temp
 .cache/
 
+# Generated silhouette assets (created by npm run assets:generate-silhouettes)
+images/animals/silhouettes/*.webp
+images/animals/silhouettes/manifest.json
+
 # Internal documentation
 AUDIT.md
 IMAGE_UPDATER_README.md

--- a/css/pages/homepage.css
+++ b/css/pages/homepage.css
@@ -780,14 +780,14 @@ html.route-home nav[class*="mobile"] {
         inset 0 -1px 0 rgba(0, 0, 0, 0.1);
     
     /* Smooth transitions for dramatic effect */
-    transition: 
-        transform 0.5s cubic-bezier(0.34, 1.56, 0.64, 1),
-        box-shadow 0.4s cubic-bezier(0.4, 0, 0.2, 1),
-        border-color 0.3s ease,
-        filter 0.4s ease;
+    transition:
+        transform 220ms cubic-bezier(0.2, 0, 0, 1),
+        border-color 180ms ease,
+        opacity 180ms ease;
     
     /* Transform origin for scale */
     transform-origin: center center;
+    will-change: transform;
 }
 
 /* Inner glow line at top */
@@ -802,13 +802,15 @@ html.route-home nav[class*="mobile"] {
     opacity: 0.7;
 }
 
-/* Hover state - standard */
-.portal-nav-btn:hover {
-    transform: translateY(-4px) scale(1.02);
-    box-shadow: 
-        0 12px 35px rgba(0, 0, 0, 0.5),
-        0 0 30px var(--btn-glow-color, rgba(0, 212, 255, 0.2)),
-        inset 0 1px 0 rgba(255, 255, 255, 0.15);
+.portal-nav-btn::after {
+    content: '';
+    position: absolute;
+    inset: -2px;
+    border-radius: inherit;
+    background: radial-gradient(circle at center, var(--btn-glow-color, rgba(0, 212, 255, 0.2)), transparent 70%);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 180ms ease;
 }
 
 /* FOCUSED STATE - Dramatic zoom effect */
@@ -827,9 +829,9 @@ html.route-home nav[class*="mobile"] {
 
 /* Dimmed state for other buttons */
 .portal-nav-btn.portal-btn-dimmed {
-    filter: brightness(0.5) blur(1px);
+    filter: brightness(0.75);
     transform: scale(0.95);
-    opacity: 0.6;
+    opacity: 0.72;
 }
 
 /* Active/click state - maintain scale with satisfying press effect */
@@ -877,6 +879,17 @@ html.route-home nav[class*="mobile"] {
 .portal-nav-btn.portal-btn-focused .btn-chevron {
     color: rgba(255, 255, 255, 0.7);
     transform: translateX(4px);
+}
+
+@media (hover: hover) and (pointer: fine) {
+    .portal-nav-btn:hover {
+        transform: translateY(-3px) scale(1.015);
+        border-color: var(--btn-accent-color, rgba(0, 212, 255, 0.7));
+    }
+
+    .portal-nav-btn:hover::after {
+        opacity: 0.8;
+    }
 }
 
 /* Button color variants with CSS custom properties */
@@ -957,13 +970,13 @@ html.route-home nav[class*="mobile"] {
         inset 0 -1px 0 rgba(0, 0, 0, 0.15);
     
     /* Match nav button transitions */
-    transition: 
-        transform 0.5s cubic-bezier(0.34, 1.56, 0.64, 1),
-        box-shadow 0.4s cubic-bezier(0.4, 0, 0.2, 1),
-        border-color 0.3s ease,
-        filter 0.4s ease;
+    transition:
+        transform 220ms cubic-bezier(0.2, 0, 0, 1),
+        border-color 180ms ease,
+        opacity 180ms ease;
     
     transform-origin: center center;
+    will-change: transform;
     animation: tournamentPulse 3s ease-in-out infinite;
 }
 
@@ -1010,16 +1023,6 @@ html.route-home nav[class*="mobile"] {
     50% { left: 100%; }
 }
 
-.portal-tournament-btn:hover {
-    transform: translateY(-4px) scale(1.03);
-    animation: none;
-    box-shadow: 
-        0 12px 40px rgba(255, 0, 68, 0.6),
-        0 0 60px rgba(255, 0, 68, 0.35),
-        inset 0 1px 0 rgba(255, 255, 255, 0.3);
-    border-color: rgba(255, 255, 255, 0.4);
-}
-
 /* FOCUSED STATE - Dramatic zoom effect (same as nav buttons) */
 .portal-tournament-btn.portal-btn-focused {
     transform: scale(1.25) translateY(-8px);
@@ -1037,9 +1040,9 @@ html.route-home nav[class*="mobile"] {
 
 /* Dimmed state */
 .portal-tournament-btn.portal-btn-dimmed {
-    filter: brightness(0.5) blur(1px);
+    filter: brightness(0.75);
     transform: scale(0.95);
-    opacity: 0.6;
+    opacity: 0.72;
     animation: none;
 }
 
@@ -1088,6 +1091,14 @@ html.route-home nav[class*="mobile"] {
 .portal-tournament-btn.portal-btn-focused .btn-chevron {
     color: rgba(255, 255, 255, 0.9);
     transform: translateX(4px);
+}
+
+@media (hover: hover) and (pointer: fine) {
+    .portal-tournament-btn:hover {
+        transform: translateY(-3px) scale(1.02);
+        animation: none;
+        border-color: rgba(255, 255, 255, 0.4);
+    }
 }
 
 /* ========================================

--- a/js/homepage.js
+++ b/js/homepage.js
@@ -37,10 +37,12 @@ const HomepageController = {
     transparencyCache: new Map(),
     silhouetteSourceCache: new Map(),
     silhouetteGenerationQueue: new Map(),
+    prebuiltSilhouetteCache: new Map(),
     transparencyCanvas: null,
     homePortalEl: null,
     desktopTrackPool: [],
     mobileTrackPool: [],
+    resizeRaf: null,
     
     // Animation state for each track
     animations: {
@@ -380,17 +382,23 @@ const HomepageController = {
 
         window.addEventListener('resize', () => {
             if (!this.initialized) return;
-
-            const wasMobile = this.animations.mobile.track !== null;
-            const isMobile = window.matchMedia('(max-width: 600px)').matches;
-            if (wasMobile !== isMobile) {
-                this.populateTracksForViewport();
+            if (this.resizeRaf) {
+                cancelAnimationFrame(this.resizeRaf);
             }
+            this.resizeRaf = requestAnimationFrame(() => {
+                this.resizeRaf = null;
 
-            // Recalculate loop dimensions after layout changes.
-            this.animations.left.height = 0;
-            this.animations.right.height = 0;
-            this.animations.mobile.width = 0;
+                const wasMobile = this.animations.mobile.track !== null;
+                const isMobile = window.matchMedia('(max-width: 600px)').matches;
+                if (wasMobile !== isMobile) {
+                    this.populateTracksForViewport();
+                }
+
+                // Recalculate loop dimensions after layout changes.
+                this.animations.left.height = 0;
+                this.animations.right.height = 0;
+                this.animations.mobile.width = 0;
+            });
         }, { passive: true });
     },
     
@@ -939,13 +947,28 @@ const HomepageController = {
         img.alt = '';
         img.draggable = false;
         img.dataset.originalSrc = src;
+        const prebuiltSilhouetteSrc = this.getPrebuiltSilhouettePath(src);
+        if (prebuiltSilhouetteSrc) {
+            img.dataset.prebuiltSilhouetteSrc = prebuiltSilhouetteSrc;
+        }
         
         const cachedTransparency = this.transparencyCache.get(src);
         if (cachedTransparency === false) {
             img.style.display = 'none';
         }
         
-        img.onerror = () => { img.style.display = 'none'; };
+        img.onerror = () => {
+            // If server-side silhouette is missing, gracefully fall back
+            // to the original source with CSS filter.
+            if (img.dataset.prebuiltSilhouetteSrc && img.src.includes('/silhouettes/')) {
+                img.classList.remove('silhouette-generated');
+                img.classList.add('silhouette-fallback-filter');
+                img.src = src;
+                return;
+            }
+
+            img.style.display = 'none';
+        };
         img.onload = () => {
             if (img.style.display === 'none') return;
 
@@ -973,11 +996,56 @@ const HomepageController = {
                 setTimeout(runValidation, 0);
             }
         };
-        img.src = src;
 
-        this.maybeUpgradeToGeneratedSilhouette(img, src);
+        if (prebuiltSilhouetteSrc) {
+            img.classList.remove('silhouette-fallback-filter');
+            img.classList.add('silhouette-generated');
+            img.src = prebuiltSilhouetteSrc;
+        } else {
+            img.src = src;
+            this.maybeUpgradeToGeneratedSilhouette(img, src);
+        }
         
         return img;
+    },
+
+    getPrebuiltSilhouettePath(src) {
+        if (!src) return null;
+        if (this.prebuiltSilhouetteCache.has(src)) {
+            return this.prebuiltSilhouetteCache.get(src);
+        }
+
+        try {
+            const url = new URL(src, window.location.origin);
+            if (url.origin !== window.location.origin) {
+                this.prebuiltSilhouetteCache.set(src, null);
+                return null;
+            }
+
+            if (!url.pathname.startsWith('/images/animals/')) {
+                this.prebuiltSilhouetteCache.set(src, null);
+                return null;
+            }
+
+            const filename = url.pathname.split('/').pop();
+            if (!filename) {
+                this.prebuiltSilhouetteCache.set(src, null);
+                return null;
+            }
+
+            const baseName = filename.replace(/\.[^.]+$/, '');
+            if (!baseName) {
+                this.prebuiltSilhouetteCache.set(src, null);
+                return null;
+            }
+
+            const prebuiltPath = `/images/animals/silhouettes/${baseName}.webp`;
+            this.prebuiltSilhouetteCache.set(src, prebuiltPath);
+            return prebuiltPath;
+        } catch {
+            this.prebuiltSilhouetteCache.set(src, null);
+            return null;
+        }
     },
 
     primeSilhouetteCache(images) {
@@ -1012,6 +1080,7 @@ const HomepageController = {
 
     maybeUpgradeToGeneratedSilhouette(img, src) {
         if (!img || !src || !this.isSilhouetteGenerationCandidate(src)) return;
+        if (this.getPrebuiltSilhouettePath(src)) return;
 
         this.getSilhouetteSource(src)
             .then((silhouetteSrc) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "eslint": "^9.39.2",
         "globals": "^17.0.0",
         "playwright": "^1.57.0",
+        "sharp": "^0.34.5",
         "vercel": "^33.0.0"
       },
       "engines": {
@@ -91,6 +92,17 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -310,6 +322,496 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
@@ -3909,6 +4411,64 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/sharp/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -4241,6 +4801,14 @@
       "integrity": "sha512-FZIXf1ksVyLcfr7M317jbB67XFJhOO1YqdTcuGaq9q5jLUoTikukZ+98TPjKiP2jC5CgmYdWWYs0s2nLSU0/1A==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "version:bump:minor": "node scripts/version/bump-site-version.js --bump minor",
     "version:bump:major": "node scripts/version/bump-site-version.js --bump major",
     "lint": "eslint js/ api/ lib/",
-    "lint:fix": "eslint js/ api/ lib/ --fix"
+    "lint:fix": "eslint js/ api/ lib/ --fix",
+    "assets:generate-silhouettes": "node scripts/assets/generate-silhouettes.js"
   },
   "keywords": [
     "animals",
@@ -38,6 +39,7 @@
     "eslint": "^9.39.2",
     "globals": "^17.0.0",
     "playwright": "^1.57.0",
+    "sharp": "^0.34.5",
     "vercel": "^33.0.0"
   },
   "engines": {

--- a/scripts/assets/generate-silhouettes.js
+++ b/scripts/assets/generate-silhouettes.js
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('node:fs/promises');
+const path = require('node:path');
+const sharp = require('sharp');
+
+const ROOT = path.resolve(__dirname, '../..');
+const SOURCE_DIR = path.join(ROOT, 'images/animals');
+const OUTPUT_DIR = path.join(SOURCE_DIR, 'silhouettes');
+const SUPPORTED_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.webp', '.avif']);
+
+async function ensureDir(dirPath) {
+    await fs.mkdir(dirPath, { recursive: true });
+}
+
+async function collectSourceImages(dirPath) {
+    const entries = await fs.readdir(dirPath, { withFileTypes: true });
+    const files = [];
+
+    for (const entry of entries) {
+        if (!entry.isFile()) continue;
+
+        const ext = path.extname(entry.name).toLowerCase();
+        if (!SUPPORTED_EXTENSIONS.has(ext)) continue;
+
+        files.push(path.join(dirPath, entry.name));
+    }
+
+    return files.sort((a, b) => a.localeCompare(b));
+}
+
+async function buildSilhouette(inputPath) {
+    const fileName = path.basename(inputPath);
+    const outputName = `${path.parse(fileName).name}.webp`;
+    const outputPath = path.join(OUTPUT_DIR, outputName);
+
+    try {
+        const resized = sharp(inputPath)
+            .rotate()
+            .resize({ width: 320, height: 320, fit: 'inside', withoutEnlargement: true })
+            .ensureAlpha();
+
+        const metadata = await resized.metadata();
+        if (!metadata.width || !metadata.height) {
+            return null;
+        }
+
+        const { data: alphaChannel, info: alphaInfo } = await resized
+            .extractChannel('alpha')
+            .raw()
+            .toBuffer({ resolveWithObject: true });
+
+        await sharp({
+            create: {
+                width: metadata.width,
+                height: metadata.height,
+                channels: 3,
+                background: { r: 255, g: 255, b: 255 }
+            }
+        })
+            .joinChannel(alphaChannel, {
+                raw: {
+                    width: alphaInfo.width,
+                    height: alphaInfo.height,
+                    channels: alphaInfo.channels
+                }
+            })
+            .webp({ quality: 82, alphaQuality: 100, effort: 4 })
+            .toFile(outputPath);
+
+        return outputName;
+    } catch (error) {
+        console.warn(`Skipping unsupported file: ${path.basename(inputPath)} (${error.message})`);
+        return null;
+    }
+}
+
+async function main() {
+    await ensureDir(OUTPUT_DIR);
+
+    const sourceImages = await collectSourceImages(SOURCE_DIR);
+    const manifest = {
+        generatedAt: new Date().toISOString(),
+        count: 0,
+        files: {}
+    };
+
+    for (const inputPath of sourceImages) {
+        const originalName = path.basename(inputPath);
+        const outputName = await buildSilhouette(inputPath);
+        if (!outputName) continue;
+
+        manifest.files[originalName] = outputName;
+        manifest.count += 1;
+    }
+
+    const manifestPath = path.join(OUTPUT_DIR, 'manifest.json');
+    await fs.writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
+
+    console.log(`Generated ${manifest.count} silhouettes in ${path.relative(ROOT, OUTPUT_DIR)}.`);
+}
+
+main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+});


### PR DESCRIPTION
### Motivation

- Provide prebuilt silhouette assets to avoid expensive client-side generation and improve load reliability for animal images.
- Improve homepage visuals and interaction responsiveness by tightening transitions, adding hover-safe effects, and reducing jank on resize.
- Add an authorable script and dependency to generate silhouette assets as part of the repo tooling.

### Description

- Introduces `scripts/assets/generate-silhouettes.js`, a Node script using `sharp` that generates `.webp` silhouette images and writes a `manifest.json` into `images/animals/silhouettes/`.
- Adds `images/animals/silhouettes/.gitkeep` and updates `.gitignore` to exclude generated silhouettes and their manifest, and adds an npm script `assets:generate-silhouettes` to `package.json` and `sharp` to devDependencies.
- Updates `js/homepage.js` to prefer prebuilt silhouettes via a new `prebuiltSilhouetteCache` and `getPrebuiltSilhouettePath(src)`, to set `img.src` to prebuilt silhouettes when available, to gracefully fall back on load/error, and to debounce window `resize` handling with `requestAnimationFrame`.
- Tweaks `css/pages/homepage.css` to refine transitions (shorter durations, `will-change`), add a radial glow overlay using `::after`, add hover media-query guards for pointer-capable devices, and adjust dimmed/active/focused styles for nav and tournament buttons.
- Updates `package-lock.json` to include `sharp` (and related optional packages) and other lockfile changes required for the asset generation tooling.

### Testing

- Ran `npm run lint` to validate JavaScript style and it completed without errors.
- Executed `node scripts/assets/generate-silhouettes.js` locally against existing `images/animals` to confirm silhouettes and `manifest.json` are produced successfully.
- Manually exercised the homepage in a local dev build to confirm prebuilt silhouettes are loaded, fallback behavior works when a silhouette is missing, and resize/hover interactions behave as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e91763f8f48320a57759a2d291e61f)