### PR TITLE
Overhaul community map analytics UX and controls

### DIFF
--- a/api/community.js
+++ b/api/community.js
@@ -420,11 +420,23 @@ async function handleVisit(req, res) {
 async function handleGlobe(req, res) {
     const SiteActivity = require('../lib/models/SiteActivity');
 
+    const trendRange = String(req.query.range || 'all').trim().toLowerCase();
     const now = new Date();
     const oneDayAgo = new Date(now.getTime() - (24 * 60 * 60 * 1000));
     const sevenDaysAgo = new Date(now.getTime() - (7 * 24 * 60 * 60 * 1000));
     const thirtyDaysAgo = new Date(now.getTime() - (30 * 24 * 60 * 60 * 1000));
-    const fourteenDaysAgo = new Date(now.getTime() - (14 * 24 * 60 * 60 * 1000));
+
+    const trendRangeDays = {
+        '14d': 14,
+        '30d': 30,
+        '90d': 90,
+        '365d': 365
+    }[trendRange] || null;
+
+    const trendDateMatch = {};
+    if (Number.isFinite(trendRangeDays) && trendRangeDays > 0) {
+        trendDateMatch.occurredAt = { $gte: new Date(now.getTime() - (trendRangeDays * 24 * 60 * 60 * 1000)) };
+    }
 
     const [summaryAgg, pointsAgg, actionsAgg, pagesAgg, trendAgg] = await Promise.all([
         SiteActivity.aggregate([
@@ -468,8 +480,8 @@ async function handleGlobe(req, res) {
                     region: { $first: '$region' },
                     country: { $first: '$country' },
                     locationRaw: { $first: '$locationRaw' },
-                    lat: { $first: '$coordinates.lat' },
-                    lng: { $first: '$coordinates.lng' },
+                    lat: { $avg: '$coordinates.lat' },
+                    lng: { $avg: '$coordinates.lng' },
                     totalEvents: { $sum: 1 },
                     totalVisits: {
                         $sum: {
@@ -488,8 +500,8 @@ async function handleGlobe(req, res) {
                     region: 1,
                     country: 1,
                     locationRaw: 1,
-                    lat: 1,
-                    lng: 1,
+                    lat: { $round: ['$lat', 5] },
+                    lng: { $round: ['$lng', 5] },
                     totalEvents: 1,
                     totalVisits: 1,
                     uniqueVisitors: {
@@ -516,7 +528,7 @@ async function handleGlobe(req, res) {
             { $limit: 8 }
         ]),
         SiteActivity.aggregate([
-            { $match: { occurredAt: { $gte: fourteenDaysAgo } } },
+            { $match: trendDateMatch },
             {
                 $group: {
                     _id: {
@@ -566,7 +578,8 @@ async function handleGlobe(req, res) {
             points: pointsAgg,
             actions: cleanedActions,
             pages: cleanedPages,
-            trend: trendAgg
+            trend: trendAgg,
+            trendRange: trendRangeDays ? `${trendRangeDays}d` : 'all'
         }
     });
 }

--- a/css/pages/community-globe.css
+++ b/css/pages/community-globe.css
@@ -166,6 +166,55 @@
     font-weight: 700;
 }
 
+#community-view .globe-context-bar {
+    margin: 0 0 10px;
+    padding: 9px;
+    border-radius: 11px;
+    border: 1px solid rgba(91, 171, 204, 0.34);
+    background: rgba(6, 19, 31, 0.8);
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+    gap: 10px;
+}
+
+#community-view .globe-context-item {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+}
+
+#community-view .globe-context-label {
+    font-size: 0.58rem;
+    letter-spacing: 0.95px;
+    text-transform: uppercase;
+    color: rgba(176, 216, 234, 0.72);
+}
+
+#community-view .globe-context-select,
+#community-view .globe-context-pill {
+    height: 32px;
+    border-radius: 8px;
+    border: 1px solid rgba(86, 170, 209, 0.34);
+    background: rgba(8, 23, 36, 0.9);
+    color: rgba(210, 241, 252, 0.95);
+    font-size: 0.7rem;
+    padding: 0 10px;
+}
+
+#community-view .globe-context-select:focus {
+    outline: none;
+    border-color: rgba(124, 221, 255, 0.7);
+    box-shadow: 0 0 0 2px rgba(0, 212, 255, 0.14);
+}
+
+#community-view .globe-context-pill {
+    display: inline-flex;
+    align-items: center;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
 #community-view .globe-stage {
     width: 100%;
     height: clamp(210px, 33vh, 290px);
@@ -425,6 +474,23 @@
     display: flex;
     flex-direction: column;
     gap: 6px;
+    max-height: 270px;
+    overflow: auto;
+    padding-right: 4px;
+}
+
+#community-view .globe-city-list::-webkit-scrollbar {
+    width: 7px;
+}
+
+#community-view .globe-city-list::-webkit-scrollbar-track {
+    border-radius: 999px;
+    background: rgba(8, 22, 36, 0.6);
+}
+
+#community-view .globe-city-list::-webkit-scrollbar-thumb {
+    border-radius: 999px;
+    background: rgba(92, 178, 218, 0.5);
 }
 
 #community-view .globe-city-row {
@@ -622,6 +688,10 @@
     #community-view .globe-advanced-grid,
     #community-view .globe-point-grid,
     #community-view .globe-breakdown-grid {
+        grid-template-columns: 1fr;
+    }
+
+    #community-view .globe-context-bar {
         grid-template-columns: 1fr;
     }
 

--- a/index.html
+++ b/index.html
@@ -1398,6 +1398,23 @@
                             <button type="button" class="globe-mode-btn" id="globe-mode-flat" data-mode="flat">Flat Map</button>
                         </div>
 
+                        <div class="globe-context-bar">
+                            <div class="globe-context-item">
+                                <span class="globe-context-label">Trend Window</span>
+                                <select id="globe-trend-range" class="globe-context-select" aria-label="Select activity trend time range">
+                                    <option value="all" selected>All Time</option>
+                                    <option value="14d">Last 14 Days</option>
+                                    <option value="30d">Last 30 Days</option>
+                                    <option value="90d">Last 90 Days</option>
+                                    <option value="365d">Last 12 Months</option>
+                                </select>
+                            </div>
+                            <div class="globe-context-item">
+                                <span class="globe-context-label">Location Scope</span>
+                                <span id="globe-location-scope" class="globe-context-pill">Global</span>
+                            </div>
+                        </div>
+
                         <div class="globe-stage">
                             <canvas id="community-globe-canvas" width="520" height="520" aria-label="Interactive global activity map"></canvas>
                             <div id="community-globe-empty" class="globe-empty">Loading global activity...</div>
@@ -1451,7 +1468,7 @@
 
                         <div class="globe-advanced-grid">
                             <div class="globe-chart-card">
-                                <h4>14-Day Activity Trend</h4>
+                                <h4 id="globe-trend-title">Activity Trend (All Time)</h4>
                                 <div class="globe-chart-wrap">
                                     <canvas id="globe-trend-chart" aria-label="Daily events and visits trend"></canvas>
                                 </div>

--- a/js/community-globe.js
+++ b/js/community-globe.js
@@ -107,6 +107,8 @@
             this.autoSpinSpeed = 0.00125;
             this.globeZoom = 1;
             this.flatZoom = 1;
+            this.flatPanX = 0;
+            this.flatPanY = 0;
 
             this.isPaused = false;
             this.isDragging = false;
@@ -215,6 +217,10 @@
                             }
                         }
                         this.dragVector = currentVector;
+                    } else if (this.mode === 'flat' && this.flatZoom > 1) {
+                        this.flatPanX += dx;
+                        this.flatPanY += dy;
+                        this.clampFlatPan();
                     }
 
                     this.lastPointerX = event.clientX;
@@ -263,6 +269,11 @@
                 const nextFlatZoom = clamp(this.flatZoom + delta, 1, 4);
                 if (nextFlatZoom !== this.flatZoom) {
                     this.flatZoom = nextFlatZoom;
+                    if (nextFlatZoom === 1) {
+                        this.flatPanX = 0;
+                        this.flatPanY = 0;
+                    }
+                    this.clampFlatPan();
                     this.flatBaseHash = '';
                 }
                 return;
@@ -404,11 +415,6 @@
             ctx.strokeStyle = 'rgba(125, 215, 255, 0.65)';
             ctx.lineWidth = 1.2;
             ctx.stroke();
-
-            ctx.beginPath();
-            ctx.arc(centerX - (radius * 0.32), centerY - (radius * 0.42), radius * 0.18, 0, Math.PI * 2);
-            ctx.fillStyle = 'rgba(208, 243, 255, 0.18)';
-            ctx.fill();
         }
 
         drawGlobeGraticule(ctx, centerX, centerY, radius) {
@@ -523,8 +529,10 @@
             const mapWidth = baseWidth * this.flatZoom;
             const mapHeight = baseHeight * this.flatZoom;
 
-            const mapX = (width - mapWidth) / 2;
-            const mapY = (height - mapHeight) / 2;
+            this.clampFlatPan(width, height);
+
+            const mapX = ((width - mapWidth) / 2) + this.flatPanX;
+            const mapY = ((height - mapHeight) / 2) + this.flatPanY;
 
             const hash = `${width}x${height}::${this.landRings.length}::${this.flatZoom.toFixed(3)}`;
             if (!this.flatBaseCanvas || this.flatBaseHash !== hash) {
@@ -609,6 +617,38 @@
             });
 
             ctx.shadowBlur = 0;
+        }
+
+        clampFlatPan(width = this.renderWidth, height = this.renderHeight) {
+            const safeWidth = Number(width) || 0;
+            const safeHeight = Number(height) || 0;
+
+            if (this.flatZoom <= 1 || !safeWidth || !safeHeight) {
+                this.flatPanX = 0;
+                this.flatPanY = 0;
+                return;
+            }
+
+            const padding = 10;
+            const maxWidth = safeWidth - (padding * 2);
+            const maxHeight = safeHeight - (padding * 2);
+            const targetAspect = 2;
+
+            let baseWidth = maxWidth;
+            let baseHeight = baseWidth / targetAspect;
+
+            if (baseHeight > maxHeight) {
+                baseHeight = maxHeight;
+                baseWidth = baseHeight * targetAspect;
+            }
+
+            const mapWidth = baseWidth * this.flatZoom;
+            const mapHeight = baseHeight * this.flatZoom;
+            const overflowX = Math.max(0, (mapWidth - safeWidth) / 2);
+            const overflowY = Math.max(0, (mapHeight - safeHeight) / 2);
+
+            this.flatPanX = clamp(this.flatPanX, -overflowX, overflowX);
+            this.flatPanY = clamp(this.flatPanY, -overflowY, overflowY);
         }
 
         projectToFlat(lat, lng, mapX, mapY, mapWidth, mapHeight) {

--- a/js/community-manager.js
+++ b/js/community-manager.js
@@ -46,7 +46,9 @@ class CommunityManager {
         this.globeMode = 'globe';
         this.globeModeBound = false;
         this.globeDirectoryBound = false;
+        this.globeControlsBound = false;
         this.globeCityFilter = '';
+        this.globeTrendRange = 'all';
         this.globeCharts = {
             trend: null,
             country: null
@@ -503,6 +505,7 @@ class CommunityManager {
 
         this.bindGlobeModeSwitch();
         this.bindGlobeDirectoryControls();
+        this.bindGlobeAnalyticsControls();
         this.applyGlobeMode(this.globeMode);
 
         this.loadGlobeAnalytics();
@@ -541,6 +544,24 @@ class CommunityManager {
         this.globeDirectoryBound = true;
     }
 
+    bindGlobeAnalyticsControls() {
+        if (this.globeControlsBound) return;
+
+        const trendRange = document.getElementById('globe-trend-range');
+        if (trendRange) {
+            trendRange.value = this.globeTrendRange;
+            trendRange.addEventListener('change', (event) => {
+                const nextRange = String(event.target.value || 'all').toLowerCase();
+                this.globeTrendRange = ['all', '14d', '30d', '90d', '365d'].includes(nextRange) ? nextRange : 'all';
+                this.updateGlobeContextChips();
+                this.loadGlobeAnalytics();
+            });
+        }
+
+        this.updateGlobeContextChips();
+        this.globeControlsBound = true;
+    }
+
     applyGlobeMode(mode) {
         const normalized = mode === 'flat' ? 'flat' : 'globe';
         this.globeMode = normalized;
@@ -575,7 +596,11 @@ class CommunityManager {
         }
 
         try {
-            const response = await fetch('/api/community?action=globe');
+            const query = new URLSearchParams({
+                action: 'globe',
+                range: this.globeTrendRange || 'all'
+            });
+            const response = await fetch(`/api/community?${query.toString()}`);
             if (!response.ok) throw new Error('Failed to load globe analytics');
 
             const result = await response.json();
@@ -593,6 +618,7 @@ class CommunityManager {
             this.renderGlobeTrendChart(payload.trend || []);
             this.renderGlobeCountryChart(payload.points || []);
             this.renderGlobeCityDirectory(payload.points || []);
+            this.updateGlobeContextChips(payload.trendRange);
 
             if (empty) {
                 empty.style.display = 'none';
@@ -761,6 +787,11 @@ class CommunityManager {
                 }
             }
         });
+
+        const title = document.getElementById('globe-trend-title');
+        if (title) {
+            title.textContent = `Activity Trend (${this.formatTrendRangeLabel(this.globeTrendRange)})`;
+        }
     }
 
     renderGlobeCountryChart(points) {
@@ -916,6 +947,7 @@ class CommunityManager {
                 this.selectedGlobeKey = key;
                 this.loadGlobePointDetails(key);
                 this.highlightSelectedCityRow();
+                this.updateGlobeContextChips();
             });
         });
 
@@ -932,6 +964,8 @@ class CommunityManager {
             row.classList.toggle('active', isActive);
             row.setAttribute('aria-pressed', isActive ? 'true' : 'false');
         });
+
+        this.updateGlobeContextChips();
     }
 
     destroyGlobeChart(chartKey) {
@@ -1024,6 +1058,8 @@ class CommunityManager {
                 </div>
             </div>
         `;
+
+        this.updateGlobeContextChips();
     }
 
     renderMiniList(items) {
@@ -1049,6 +1085,43 @@ class CommunityManager {
                 </div>
             `;
         }).join('');
+    }
+
+    updateGlobeContextChips(serverRange = null) {
+        if (serverRange && ['all', '14d', '30d', '90d', '365d'].includes(serverRange)) {
+            this.globeTrendRange = serverRange;
+        }
+
+        const rangeSelect = document.getElementById('globe-trend-range');
+        if (rangeSelect && rangeSelect.value !== this.globeTrendRange) {
+            rangeSelect.value = this.globeTrendRange;
+        }
+
+        const trendTitle = document.getElementById('globe-trend-title');
+        if (trendTitle) {
+            trendTitle.textContent = `Activity Trend (${this.formatTrendRangeLabel(this.globeTrendRange)})`;
+        }
+
+        const locationScope = document.getElementById('globe-location-scope');
+        if (locationScope) {
+            const selectedPoint = (this.lastGlobePayload?.points || []).find(point => point?.key === this.selectedGlobeKey);
+            const label = selectedPoint
+                ? (selectedPoint.locationRaw || [selectedPoint.city, selectedPoint.region, selectedPoint.country].filter(Boolean).join(', ') || 'Unknown location')
+                : 'Global';
+            locationScope.textContent = label;
+        }
+    }
+
+    formatTrendRangeLabel(range) {
+        const normalized = String(range || 'all').toLowerCase();
+        const labels = {
+            all: 'All Time',
+            '14d': 'Last 14 Days',
+            '30d': 'Last 30 Days',
+            '90d': 'Last 90 Days',
+            '365d': 'Last 12 Months'
+        };
+        return labels[normalized] || labels.all;
     }
 
     formatDateTime(value) {
@@ -2157,4 +2230,3 @@ class CommunityManager {
         return div.innerHTML;
     }
 }
-


### PR DESCRIPTION
### Motivation
- Improve the community map/globe UX to address misplaced hotspots and a distracting globe shine while making analytics more statistics‑focused and easier to explore.  
- Make activity trend default to all time and allow clean selection of time windows (14d/30d/90d/365d) with a compact, always visible UI.  
- Reduce long page scrolling caused by the location directory and surface persistent context (selected location + time window) for all stats.  
- Enable panning on the flat map when zoomed and tighten hotspot coordinate handling for more accurate placements.

### Description
- Added a persistent analytics context bar with `Trend Window` selector and `Location Scope` pill and updated the trend card heading to reflect the active range; UI changes in `index.html` and `css/pages/community-globe.css`.  
- Wired trend-range controls through `js/community-manager.js` so the UI sends `range` to the API and updates charts, and added helper methods to keep context chips in sync.  
- Extended `api/community.js` `handleGlobe` to accept `range` (defaults to `all`), return `trendRange`, compute trend aggregation for the selected window, and average stored coordinates per `locationKey` (averaging + rounding).  
- Implemented flat-map pan/drag behavior when zoomed (`flatPanX/flatPanY` + `clampFlatPan`) and removed the globe shine highlight for a cleaner globe render in `js/community-globe.js`.  
- Moved location directory into a scrollable container with styled scrollbar and size limits to reduce page scrolling and improve scanability in `css/pages/community-globe.css`.  
- Hooked selected location state into the visible `Location Scope` indicator and refreshed charts/insights when selection or range changes via `js/community-manager.js`.

### Testing
- Ran `npm run lint` to validate JavaScript; the lint run completed successfully with existing repository warnings but no new errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e92db7fc60832098c965a2990a72ab)