### PR TITLE
Load route assets on demand

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,11 +107,6 @@
     <!-- Page-specific CSS (loaded async) -->
     <link rel="stylesheet" href="/css/pages/homepage.css">
     <link rel="stylesheet" href="/css/components/about-info-btn.css">
-    <link rel="stylesheet" href="/tournament-v4.css" media="print" onload="this.media='all'">
-    <link rel="stylesheet" href="/compare-page.css" media="print" onload="this.media='all'">
-    <link rel="stylesheet" href="/community-page.css" media="print" onload="this.media='all'">
-    <link rel="stylesheet" href="/css/pages/community-globe.css">
-    <link rel="stylesheet" href="/css/pages/battlepoints.css" media="print" onload="this.media='all'">
     
     <!-- Mobile-specific styles (loaded last to override) -->
     <link rel="stylesheet" href="/css/mobile.css" media="print" onload="this.media='all'">
@@ -3030,13 +3025,7 @@
     <!-- Audio Manager (must load before other scripts) -->
     <script src="/js/audio.js"></script>
     
-    <!-- Page managers (must load before main.js initializes them) -->
-    <script src="/js/rankings.js"></script>
-    <script src="/js/tournament.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/three@0.165.0/build/three.min.js"></script>
-    <script src="/js/community-globe.js"></script>
-    <script src="/js/community-manager.js"></script>
-    <script src="/js/battlepoints.js"></script>
+    <!-- Lightweight shared modules -->
     <script src="/js/homepage.js"></script>
     <script src="/js/social.js"></script>
     
@@ -3044,7 +3033,5 @@
     <script src="/js/main.js" defer></script>
     
     <!-- Page-specific enhancements -->
-    <script src="/js/compare.js" defer></script>
-    <script src="/js/community.js" defer></script>
 </body>
 </html>

--- a/js/community-manager.js
+++ b/js/community-manager.js
@@ -18,7 +18,6 @@
 /**
  * Community Manager - Handles general chat and comments feed
  */
-// eslint-disable-next-line no-unused-vars
 class CommunityManager {
     constructor(app) {
         this.app = app;
@@ -2231,3 +2230,4 @@ class CommunityManager {
         return div.innerHTML;
     }
 }
+window.CommunityManager = CommunityManager;

--- a/js/main.js
+++ b/js/main.js
@@ -351,7 +351,12 @@ class AnimalStatsApp {
 
     ensureRankingsManager() {
         if (this.rankingsManager) return this.rankingsManager;
-        this.rankingsManager = new RankingsManager(this);
+        const ManagerClass = window.RankingsManager || (typeof RankingsManager !== 'undefined' ? RankingsManager : null);
+        if (!ManagerClass) {
+            console.warn("RankingsManager is not loaded yet. Call loadRouteAssets('rankings') before initializing rankings.");
+            return null;
+        }
+        this.rankingsManager = new ManagerClass(this);
         this.rankingsManager.init();
         window.rankingsManager = this.rankingsManager;
         return this.rankingsManager;
@@ -359,7 +364,12 @@ class AnimalStatsApp {
 
     ensureTournamentManager() {
         if (this.tournamentManager) return this.tournamentManager;
-        this.tournamentManager = new TournamentManager(this);
+        const ManagerClass = window.TournamentManager || (typeof TournamentManager !== 'undefined' ? TournamentManager : null);
+        if (!ManagerClass) {
+            console.warn("TournamentManager is not loaded yet. Call loadRouteAssets('tournament') before initializing tournaments.");
+            return null;
+        }
+        this.tournamentManager = new ManagerClass(this);
         this.tournamentManager.init();
         window.tournamentManager = this.tournamentManager;
         return this.tournamentManager;
@@ -367,17 +377,25 @@ class AnimalStatsApp {
 
     ensureCommunityManager() {
         if (this.communityManager) return this.communityManager;
-        this.communityManager = new CommunityManager(this);
+        const ManagerClass = window.CommunityManager || (typeof CommunityManager !== 'undefined' ? CommunityManager : null);
+        if (!ManagerClass) {
+            console.warn("CommunityManager is not loaded yet. Call loadRouteAssets('community') before initializing community.");
+            return null;
+        }
+        this.communityManager = new ManagerClass(this);
         this.communityManager.init();
         window.communityManager = this.communityManager;
         return this.communityManager;
     }
 
     ensureBattlepointsManager() {
-        if (this.battlepointsManager || !window.BattlepointsManager) {
-            return this.battlepointsManager;
+        if (this.battlepointsManager) return this.battlepointsManager;
+        const ManagerClass = window.BattlepointsManager || (typeof BattlepointsManager !== 'undefined' ? BattlepointsManager : null);
+        if (!ManagerClass) {
+            console.warn("BattlepointsManager is not loaded yet. Call loadRouteAssets('battlepoints') before initializing battle points.");
+            return null;
         }
-        this.battlepointsManager = new BattlepointsManager(this);
+        this.battlepointsManager = new ManagerClass(this);
         this.battlepointsManager.init();
         window.battlepointsManager = this.battlepointsManager;
         return this.battlepointsManager;
@@ -387,28 +405,8 @@ class AnimalStatsApp {
         if (this._deferredInitStarted) return;
         this._deferredInitStarted = true;
 
-        this.runWhenIdle(async () => {
-            try {
-                const rankingsManager = this.ensureRankingsManager();
-                await rankingsManager.fetchRankings();
-
-                // Re-apply ranking sort once rankings data arrives.
-                if (this.state.filters.sort === 'rank') {
-                    const shouldRenderGrid = this.gridRendered || this.state.view === 'stats' || this.state.view === 'compare';
-                    this.applyFilters({ renderGrid: shouldRenderGrid });
-                }
-
-                if (this.state.selectedAnimal) {
-                    this.updateBattleRecord(this.state.selectedAnimal);
-                }
-            } catch (error) {
-                console.warn('Deferred rankings load failed:', error);
-            }
-        }, 800);
-
-        this.runWhenIdle(() => this.ensureTournamentManager(), 1200);
-        this.runWhenIdle(() => this.ensureCommunityManager(), 1400);
-        this.runWhenIdle(() => this.ensureBattlepointsManager(), 1600);
+        // Route-heavy managers are intentionally not preloaded here. They are
+        // injected by loadRouteAssets(routeName) on the first visit to their route.
     }
 
     /**
@@ -460,16 +458,19 @@ class AnimalStatsApp {
         });
 
         // Compare route
-        router.on('/compare', () => {
+        router.on('/compare', async () => {
+            await window.loadRouteAssets?.('compare');
             this.switchView('compare', false);
         });
 
         // Rankings route
-        router.on('/rankings', () => {
+        router.on('/rankings', async () => {
+            await window.loadRouteAssets?.('rankings');
             this.switchView('rankings', false);
         });
 
-        const handleCommunityRoute = (tabName = 'chat', options = {}) => {
+        const handleCommunityRoute = async (tabName = 'chat', options = {}) => {
+            await window.loadRouteAssets?.('community');
             const requestedTab = typeof tabName === 'string' ? tabName.toLowerCase() : 'chat';
             const communityManager = this.ensureCommunityManager();
             const normalizedTab = communityManager.normalizeTabName(requestedTab);
@@ -496,17 +497,18 @@ class AnimalStatsApp {
 
         // Community route (tab-aware sub-pages)
         router.on('/community/:tab', (params) => {
-            handleCommunityRoute(params.tab);
+            return handleCommunityRoute(params.tab);
         });
 
         // Legacy/default community route fallback
         router.on('/community', () => {
             const legacyTab = new URLSearchParams(window.location.search).get('tab');
-            handleCommunityRoute(legacyTab || 'chat', { replace: true });
+            return handleCommunityRoute(legacyTab || 'chat', { replace: true });
         });
 
         // Battle Points route
-        router.on('/battlepoints', () => {
+        router.on('/battlepoints', async () => {
+            await window.loadRouteAssets?.('battlepoints');
             this.switchView('battlepoints', false);
         });
 
@@ -516,9 +518,11 @@ class AnimalStatsApp {
         });
 
         // Tournament route
-        router.on('/tournament', () => {
+        router.on('/tournament', async () => {
+            await window.loadRouteAssets?.('tournament');
             // Ensure a base view is active before showing tournament overlay
             if (this.state.view === 'home' || !this.state.view) {
+                await window.loadRouteAssets?.('rankings');
                 this.switchView('rankings', false);
             }
             // Show tournament modal on top of current view
@@ -1856,7 +1860,7 @@ class AnimalStatsApp {
     /**
      * Open comments modal for the currently selected animal (Stats view)
      */
-    openStatsComments() {
+    async openStatsComments() {
         if (!this.state.selectedAnimal) {
             Auth.showToast('Please select an animal first');
             return;
@@ -1865,6 +1869,7 @@ class AnimalStatsApp {
         const animal = this.state.selectedAnimal;
         const animalId = animal._id || animal.id;
         
+        await window.loadRouteAssets?.('rankings');
         // Use RankingsManager's comments modal
         const rankingsManager = this.ensureRankingsManager();
         if (rankingsManager?.openCommentsModal) {
@@ -2206,7 +2211,7 @@ class AnimalStatsApp {
             if (this.dom.sharedBottomBar) this.dom.sharedBottomBar.style.display = 'none';
             
             // Fetch rankings when entering rankings view
-            this.ensureRankingsManager().fetchRankings();
+            this.ensureRankingsManager()?.fetchRankings();
         } else if (viewName === 'community') {
             // Hide grid and bottom bar in community view (always hidden)
             this.dom.gridWrapper.classList.add('hidden');
@@ -2214,7 +2219,7 @@ class AnimalStatsApp {
             if (this.dom.sharedBottomBar) this.dom.sharedBottomBar.style.display = 'none';
             
             // Load community content when entering
-            this.ensureCommunityManager().onViewEnter();
+            this.ensureCommunityManager()?.onViewEnter();
         } else if (viewName === 'battlepoints') {
             // Hide grid and bottom bar in battlepoints view
             this.dom.gridWrapper.classList.add('hidden');

--- a/js/rankings.js
+++ b/js/rankings.js
@@ -18,7 +18,6 @@
  * Rankings Module
  * Handles Power Rankings voting and comments
  */
-// eslint-disable-next-line no-unused-vars
 class RankingsManager {
     constructor(app) {
         this.app = app;
@@ -1971,4 +1970,4 @@ class RankingsManager {
 }
 
 // ========================================
-
+window.RankingsManager = RankingsManager;

--- a/js/router.js
+++ b/js/router.js
@@ -15,6 +15,114 @@
 
 'use strict';
 
+
+/**
+ * Route asset loader registry.
+ * Scripts/styles are injected once and cached for repeat navigations.
+ */
+const ROUTE_ASSET_DEFINITIONS = {
+    rankings: {
+        styles: ['/css/pages/rankings.css'],
+        scripts: ['/js/rankings.js']
+    },
+    tournament: {
+        styles: ['/tournament-v4.css', '/css/pages/tournament.css'],
+        scripts: ['/js/tournament.js']
+    },
+    community: {
+        styles: ['/community-page.css', '/css/pages/community.css', '/css/pages/community-globe.css'],
+        scripts: [
+            'https://cdn.jsdelivr.net/npm/three@0.165.0/build/three.min.js',
+            '/js/community-globe.js',
+            '/js/community-manager.js',
+            '/js/community.js'
+        ]
+    },
+    compare: {
+        styles: ['/compare-page.css', '/css/pages/compare.css'],
+        scripts: ['/js/compare.js']
+    },
+    battlepoints: {
+        styles: ['/css/pages/battlepoints.css'],
+        scripts: ['/js/battlepoints.js']
+    }
+};
+
+const routeAssetPromises = new Map();
+const routeStylePromises = new Map();
+const routeScriptPromises = new Map();
+
+function loadStylesheetOnce(href) {
+    if (routeStylePromises.has(href)) return routeStylePromises.get(href);
+
+    const existing = document.querySelector(`link[rel="stylesheet"][href="${href}"]`);
+    if (existing) {
+        const promise = Promise.resolve(existing);
+        routeStylePromises.set(href, promise);
+        return promise;
+    }
+
+    const promise = new Promise((resolve, reject) => {
+        const link = document.createElement('link');
+        link.rel = 'stylesheet';
+        link.href = href;
+        link.dataset.routeAsset = 'true';
+        link.onload = () => resolve(link);
+        link.onerror = () => reject(new Error(`Failed to load stylesheet: ${href}`));
+        document.head.appendChild(link);
+    });
+
+    routeStylePromises.set(href, promise);
+    return promise;
+}
+
+function loadScriptOnce(src) {
+    if (routeScriptPromises.has(src)) return routeScriptPromises.get(src);
+
+    const existing = document.querySelector(`script[src="${src}"]`);
+    if (existing) {
+        const promise = Promise.resolve(existing);
+        routeScriptPromises.set(src, promise);
+        return promise;
+    }
+
+    const promise = new Promise((resolve, reject) => {
+        const script = document.createElement('script');
+        script.src = src;
+        script.dataset.routeAsset = 'true';
+        script.onload = () => resolve(script);
+        script.onerror = () => reject(new Error(`Failed to load script: ${src}`));
+        document.body.appendChild(script);
+    });
+
+    routeScriptPromises.set(src, promise);
+    return promise;
+}
+
+function loadRouteAssets(routeName) {
+    const assets = ROUTE_ASSET_DEFINITIONS[routeName];
+    if (!assets) return Promise.resolve();
+    if (routeAssetPromises.has(routeName)) return routeAssetPromises.get(routeName);
+
+    const promise = (async () => {
+        await Promise.all((assets.styles || []).map(loadStylesheetOnce));
+
+        // Load scripts in order so route dependencies are available before managers initialize.
+        for (const src of (assets.scripts || [])) {
+            await loadScriptOnce(src);
+        }
+    })();
+
+    routeAssetPromises.set(routeName, promise);
+    return promise;
+}
+
+window.loadRouteAssets = loadRouteAssets;
+window.routeAssetRegistry = {
+    definitions: ROUTE_ASSET_DEFINITIONS,
+    loaded: routeAssetPromises
+};
+
 class Router {
     constructor() {
         this.routes = [];
@@ -160,8 +268,13 @@ class Router {
                     params[name] = decodeURIComponent(match[index + 1]);
                 });
 
-                // Call handler
-                route.handler(params);
+                // Call handler. Route handlers may lazily load assets before switching views.
+                const result = route.handler(params);
+                if (result && typeof result.catch === 'function') {
+                    result.catch((error) => {
+                        console.error(`Error handling route ${route.path}:`, error);
+                    });
+                }
                 return;
             }
         }

--- a/js/tournament.js
+++ b/js/tournament.js
@@ -17,7 +17,6 @@
 /**
  * Tournament Manager - Handles bracket tournaments
  */
-// eslint-disable-next-line no-unused-vars
 class TournamentManager {
     constructor(app) {
         this.app = app;
@@ -2634,4 +2633,4 @@ class TournamentManager {
 }
 
 // ========================================
-
+window.TournamentManager = TournamentManager;


### PR DESCRIPTION
### Motivation
- Reduce initial page boot weight by keeping only minimal core boot code in `index.html` and deferring route-heavy scripts/styles until a route is visited.
- Ensure routing, auth state, and shared utilities remain available at first paint while loading large page managers (rankings, tournament, community, compare, battlepoints) lazily.

### Description
- Removed route-heavy styles and scripts from the global boot list in `index.html` and kept only core/shared modules (`core.js`, `router.js`, `auth.js`, `audio.js`, `homepage.js`, `social.js`, `main.js`).
- Added a cached route asset loader in `js/router.js` with `ROUTE_ASSET_DEFINITIONS` and helper functions `loadRouteAssets`, `loadScriptOnce`, and `loadStylesheetOnce` to inject scripts/styles once and cache promises.
- Updated route handlers in `js/main.js` to `await window.loadRouteAssets(...)` for `compare`, `rankings`, `community`, `battlepoints`, and `tournament` so each route’s assets are loaded the first time the route is visited.
- Made manager initialization resilient to dynamic loading by exporting manager classes to `window` from their modules and changing `ensure*Manager()` in `js/main.js` to check for the manager class and warn if assets are not yet loaded; also adjusted deferred initialization to avoid preloading route-heavy managers.
- Ensured route-backed features that call into those managers (for example `openStatsComments`) load the required route assets before invoking manager APIs.

### Testing
- Ran `npm run lint`; lint completed with no blocking errors (only non-blocking warnings where present).
- Performed a syntax check with `node --check` across the modified JS files (`js/router.js`, `js/main.js`, `js/rankings.js`, `js/tournament.js`, `js/community-manager.js`, `js/compare.js`, `js/community.js`, `js/battlepoints.js`, `js/community-globe.js`) and all passed without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdd5d6208083209e4fb1cb814b1ed9)