### PR TITLE
Add shared moderation filters and integrate into auth, comments, and chat

### DIFF
--- a/api/auth.js
+++ b/api/auth.js
@@ -14,6 +14,7 @@ const User = require('../lib/models/User');
 const jwt = require('jsonwebtoken');
 const { notifyDiscord } = require('../lib/discord');
 const { verifyToken, JWT_SECRET } = require('../lib/auth');
+const { validatePublicName } = require('../lib/moderation');
 const { 
     XP_REWARDS, 
     xpToNext, 
@@ -170,6 +171,11 @@ async function handleSignup(req, res) {
             success: false,
             error: 'Password must be at least 6 characters'
         });
+    }
+
+    const usernameModeration = validatePublicName(username);
+    if (!usernameModeration.valid) {
+        return res.status(400).json({ success: false, error: usernameModeration.error });
     }
 
     const existingUser = await User.findOne({
@@ -355,6 +361,11 @@ async function handleUpdateProfile(req, res) {
             return res.status(400).json({ success: false, error: 'Username can only contain letters, numbers, and underscores' });
         }
 
+        const usernameModeration = validatePublicName(newUsername);
+        if (!usernameModeration.valid) {
+            return res.status(400).json({ success: false, error: usernameModeration.error });
+        }
+
         // Check if username is already taken (by another user)
         const escapedUsername = newUsername.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
         const existingUser = await User.findOne({ 
@@ -404,6 +415,11 @@ async function handleUpdateProfile(req, res) {
         }
         if (newDisplayName.length > 30) {
             return res.status(400).json({ success: false, error: 'Display name cannot exceed 30 characters' });
+        }
+
+        const displayNameModeration = validatePublicName(newDisplayName);
+        if (!displayNameModeration.valid) {
+            return res.status(400).json({ success: false, error: displayNameModeration.error });
         }
         
         user.displayName = newDisplayName;

--- a/api/chat.js
+++ b/api/chat.js
@@ -16,6 +16,7 @@ const Comment = require('../lib/models/Comment');
 const Animal = require('../lib/models/Animal');
 const { verifyToken } = require('../lib/auth');
 const { notifyDiscord } = require('../lib/discord');
+const { maskBlockedTerms } = require('../lib/moderation');
 
 module.exports = async function handler(req, res) {
     res.setHeader('Access-Control-Allow-Origin', '*');
@@ -316,6 +317,9 @@ async function handlePost(req, res) {
         return res.status(400).json({ success: false, error: 'Message too long (max 500 characters)' });
     }
 
+    const trimmedContent = content.trim();
+    const publicContent = maskBlockedTerms(trimmedContent);
+
     // Get user's profile info for display
     const User = require('../lib/models/User');
     const userDoc = await User.findById(user.id).select('displayName profileAnimal');
@@ -329,7 +333,7 @@ async function handlePost(req, res) {
     }
 
     const message = await ChatMessage.create({
-        content: content.trim(),
+        content: publicContent,
         authorId: user.id,
         authorUsername: userDoc?.displayName || user.username,
         profileAnimal: userDoc?.profileAnimal || null,
@@ -342,7 +346,7 @@ async function handlePost(req, res) {
     const msgType = parentId ? 'chat_reply' : 'chat_message';
     await notifyDiscord(msgType, {
         user: userDoc?.displayName || user.username,
-        content: content.trim()
+        content: publicContent
     }, req);
 
     return res.status(201).json({

--- a/api/comments.js
+++ b/api/comments.js
@@ -7,6 +7,7 @@ const { connectToDatabase } = require('../lib/mongodb');
 const Comment = require('../lib/models/Comment');
 const { verifyToken } = require('../lib/auth');
 const { notifyDiscord } = require('../lib/discord');
+const { maskBlockedTerms } = require('../lib/moderation');
 
 module.exports = async function handler(req, res) {
     res.setHeader('Access-Control-Allow-Origin', '*');
@@ -173,12 +174,15 @@ async function handlePost(req, res) {
         return res.status(400).json({ success: false, error: 'Comment too long (max 1000 characters)' });
     }
 
+    const trimmedContent = content.trim();
+    const publicContent = maskBlockedTerms(trimmedContent);
+
     // Get user's profile info for display
     const User = require('../lib/models/User');
     const userDoc = await User.findById(user.id).select('displayName profileAnimal');
 
     const commentData = {
-        content: content.trim(),
+        content: publicContent,
         authorId: user.id,
         authorUsername: userDoc?.displayName || user.username,
         profileAnimal: userDoc?.profileAnimal || null,
@@ -206,7 +210,7 @@ async function handlePost(req, res) {
             user: displayName,
             replyTo: parentAuthor,
             target: parent.animalName || parent.comparisonKey || 'Unknown',
-            content: content.substring(0, 100) + (content.length > 100 ? '...' : '')
+            content: publicContent.substring(0, 100) + (publicContent.length > 100 ? '...' : '')
         }, req);
     } else {
         // New top-level comment
@@ -233,7 +237,7 @@ async function handlePost(req, res) {
         await notifyDiscord('comment', {
             user: displayName,
             target: targetType === 'animal' ? animalName : comparisonKey,
-            content: content.substring(0, 100) + (content.length > 100 ? '...' : '')
+            content: publicContent.substring(0, 100) + (publicContent.length > 100 ? '...' : '')
         }, req);
     }
 

--- a/config/moderation.json
+++ b/config/moderation.json
@@ -1,0 +1,6 @@
+{
+  "blockedTerms": [
+    "badword",
+    "offensiveword"
+  ]
+}

--- a/lib/moderation.js
+++ b/lib/moderation.js
@@ -1,0 +1,159 @@
+/**
+ * Shared moderation helpers for public names and user-generated content.
+ *
+ * Blocked terms can be configured with a comma-separated environment variable:
+ *   MODERATION_BLOCKED_TERMS="term one,term two"
+ * or the legacy alias:
+ *   BANNED_WORDS="term one,term two"
+ *
+ * If no environment variable is set, terms are loaded from config/moderation.json.
+ */
+
+const moderationConfig = require('../config/moderation.json');
+
+const SEPARATOR_PATTERN = /[\s\-_.|/\\]+/g;
+const SEPARATOR_REGEX_SOURCE = '[\\s\\-_.|/\\\\]*';
+const LEET_MAP = {
+    '0': 'o',
+    '1': 'i',
+    '!': 'i',
+    '|': 'i',
+    '3': 'e',
+    '4': 'a',
+    '@': 'a',
+    '5': 's',
+    '$': 's',
+    '7': 't',
+    '+': 't',
+    '8': 'b'
+};
+const CHAR_VARIANTS = {
+    a: 'a4@',
+    b: 'b8',
+    e: 'e3',
+    i: 'i1!|',
+    o: 'o0',
+    s: 's5$',
+    t: 't7+'
+};
+
+function parseEnvTerms(value) {
+    if (!value) return [];
+    return value
+        .split(',')
+        .map(term => term.trim())
+        .filter(Boolean);
+}
+
+function getConfiguredTerms() {
+    const envTerms = parseEnvTerms(process.env.MODERATION_BLOCKED_TERMS || process.env.BANNED_WORDS);
+    if (envTerms.length > 0) return envTerms;
+
+    if (Array.isArray(moderationConfig.blockedTerms)) {
+        return moderationConfig.blockedTerms;
+    }
+
+    return [];
+}
+
+function replaceLeetCharacters(text) {
+    return text.replace(/[0134578!|@$+]/g, char => LEET_MAP[char] || char);
+}
+
+function normalizeForModeration(text) {
+    return String(text || '')
+        .normalize('NFKD')
+        .replace(/[\u0300-\u036f]/g, '')
+        .toLowerCase()
+        .replace(SEPARATOR_PATTERN, '')
+        .replace(/(.)\1+/g, '$1')
+        .split('')
+        .map(char => LEET_MAP[char] || char)
+        .join('')
+        .replace(/[^a-z0-9]/g, '');
+}
+
+function normalizeText(text) {
+    return normalizeForModeration(text);
+}
+
+function getBlockedTerms() {
+    return getConfiguredTerms()
+        .map(term => ({ raw: term, normalized: normalizeForModeration(term) }))
+        .filter(term => term.normalized.length > 0);
+}
+
+function containsBlockedTerm(text) {
+    const normalizedText = normalizeForModeration(text);
+    if (!normalizedText) return false;
+
+    return getBlockedTerms().some(term => normalizedText.includes(term.normalized));
+}
+
+function escapeRegexChar(char) {
+    return char.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function characterPattern(char) {
+    const normalizedChar = replaceLeetCharacters(char.toLowerCase());
+    const variants = CHAR_VARIANTS[normalizedChar] || normalizedChar;
+    const escapedVariants = variants.split('').map(escapeRegexChar).join('');
+    return `[${escapedVariants}]+`;
+}
+
+function buildTermRegex(term) {
+    const normalizedTerm = normalizeForModeration(term);
+    if (!normalizedTerm) return null;
+
+    const pattern = normalizedTerm
+        .split('')
+        .map(characterPattern)
+        .join(SEPARATOR_REGEX_SOURCE);
+
+    return new RegExp(pattern, 'gi');
+}
+
+function maskMatch(match) {
+    const visibleLength = normalizeForModeration(match).length;
+    return '*'.repeat(Math.max(4, visibleLength));
+}
+
+function maskBlockedTerms(text) {
+    let masked = String(text || '');
+
+    getConfiguredTerms().forEach((term) => {
+        const regex = buildTermRegex(term);
+        if (!regex) return;
+        masked = masked.replace(regex, maskMatch);
+    });
+
+    return masked;
+}
+
+function validatePublicName(text) {
+    const value = String(text || '').trim();
+
+    if (!value) {
+        return {
+            valid: false,
+            error: 'Public name cannot be empty'
+        };
+    }
+
+    if (containsBlockedTerm(value)) {
+        return {
+            valid: false,
+            error: 'Public name contains blocked language. Please choose another name.'
+        };
+    }
+
+    return { valid: true };
+}
+
+module.exports = {
+    containsBlockedTerm,
+    maskBlockedTerms,
+    normalizeText,
+    normalizeForModeration,
+    validatePublicName
+};


### PR DESCRIPTION
### Motivation
- Provide a central, configurable moderation utility to detect and handle banned/obfuscated words across the API. 
- Prevent blocked terms in public-facing names and ensure user-generated content is sanitized before storage/display. 
- Support both environment-driven and checked-in admin configuration for blocked terms. 

### Description
- Added a new shared module `lib/moderation.js` that loads blocked terms from `MODERATION_BLOCKED_TERMS` or `BANNED_WORDS` environment variables (highest precedence) or falls back to `config/moderation.json`, and exposes `containsBlockedTerm`, `maskBlockedTerms`, `normalizeText`, `normalizeForModeration`, and `validatePublicName`.
- Implemented a normalization pipeline (lowercasing, diacritic removal, separator/leet handling, collapsing repeated characters) and a regex builder to catch simple obfuscation when masking/detecting terms.
- Integrated `validatePublicName()` into `api/auth.js` to reject blocked usernames and display names during signup and profile updates with a clear error message.
- Integrated `maskBlockedTerms()` into `api/comments.js` and `api/chat.js` to mask blocked terms before saving and before sending notification snippets to Discord; masked content is stored and returned publicly (original unmasked content is not preserved by these changes).
- Added initial admin config file `config/moderation.json` with placeholder blocked terms and updated relevant `require` imports in modified files.

### Testing
- Ran linting via `npm run lint` and it completed without errors.
- Performed an inline smoke test by requiring `lib/moderation.js` and exercising `normalizeText`, `containsBlockedTerm`, `maskBlockedTerms`, and `validatePublicName` against obfuscated samples, which produced expected detection/masking output.
- No automated unit tests were added in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0045e5a9e08320a2cc1ae38f889aa3)