### PR TITLE
Add Google OAuth account linking

### DIFF
--- a/api/auth.js
+++ b/api/auth.js
@@ -8,6 +8,10 @@
  * GET/POST /api/auth?action=rewards - XP/BP rewards system
  * POST /api/auth?action=prestige - Prestige at level 100
  * POST /api/auth?action=flag-rename - Admin-only: require a user to rename
+ * GET /api/auth?action=google-start - Begin Google OAuth sign in
+ * GET /api/auth?action=google-callback - Complete Google OAuth sign in
+ * GET /api/auth?action=link-google - Begin linking Google to the current user
+ * POST /api/auth?action=unlink-google - Unlink Google from the current user
  */
 
 const { connectToDatabase } = require('../lib/mongodb');
@@ -34,6 +38,11 @@ const LOGIN_LIMIT = { windowMs: 15 * 60 * 1000, max: 5 };
 const SIGNUP_LIMIT = { windowMs: 60 * 60 * 1000, max: 5 };
 const attemptBuckets = new Map();
 const GENERIC_AUTH_ERROR = 'Unable to complete this request. Please check your details and try again later.';
+const GOOGLE_PROVIDER = 'google';
+const GOOGLE_OAUTH_SCOPES = ['openid', 'email', 'profile'];
+const GOOGLE_STATE_COOKIE = 'abs_google_oauth_state';
+const GOOGLE_STATE_MAX_AGE_SECONDS = 10 * 60;
+const GOOGLE_AUTO_LINK_VERIFIED_EMAILS = process.env.GOOGLE_AUTO_LINK_VERIFIED_EMAILS === 'true';
 
 function normalizeIdentifier(value) {
     return String(value || '').trim().toLowerCase();
@@ -152,6 +161,30 @@ async function sendPasswordResetEmail(req, user, token) {
     });
 }
 
+function getSafeReturnPath(value) {
+    const raw = String(value || '').trim();
+    if (!raw || !raw.startsWith('/') || raw.startsWith('//') || raw.includes('://')) {
+        return '/';
+    }
+    return raw;
+}
+
+function buildRedirectUrl(req, path, params = {}) {
+    const url = new URL(path, getBaseUrl(req));
+    Object.entries(params).forEach(([key, value]) => {
+        if (value !== undefined && value !== null && value !== '') {
+            url.searchParams.set(key, String(value));
+        }
+    });
+    return url.toString();
+}
+
+function redirectTo(res, location) {
+    res.statusCode = 302;
+    res.setHeader('Location', location);
+    return res.end();
+}
+
 function parseCookies(req) {
     return String(req.headers.cookie || '').split(';').reduce((cookies, pair) => {
         const index = pair.indexOf('=');
@@ -170,14 +203,35 @@ function getRequestToken(req) {
     return parseCookies(req)[AUTH_COOKIE_NAME] || null;
 }
 
+function appendSetCookie(res, cookie) {
+    const existing = res.getHeader('Set-Cookie');
+    if (!existing) {
+        res.setHeader('Set-Cookie', cookie);
+    } else if (Array.isArray(existing)) {
+        res.setHeader('Set-Cookie', [...existing, cookie]);
+    } else {
+        res.setHeader('Set-Cookie', [existing, cookie]);
+    }
+}
+
 function setAuthCookie(res, token) {
     const secure = process.env.NODE_ENV === 'production' ? '; Secure' : '';
-    res.setHeader('Set-Cookie', `${AUTH_COOKIE_NAME}=${encodeURIComponent(token)}; Max-Age=${TOKEN_MAX_AGE_SECONDS}; Path=/; HttpOnly; SameSite=Lax${secure}`);
+    appendSetCookie(res, `${AUTH_COOKIE_NAME}=${encodeURIComponent(token)}; Max-Age=${TOKEN_MAX_AGE_SECONDS}; Path=/; HttpOnly; SameSite=Lax${secure}`);
 }
 
 function clearAuthCookie(res) {
     const secure = process.env.NODE_ENV === 'production' ? '; Secure' : '';
-    res.setHeader('Set-Cookie', `${AUTH_COOKIE_NAME}=; Max-Age=0; Path=/; HttpOnly; SameSite=Lax${secure}`);
+    appendSetCookie(res, `${AUTH_COOKIE_NAME}=; Max-Age=0; Path=/; HttpOnly; SameSite=Lax${secure}`);
+}
+
+function setGoogleStateCookie(res, state) {
+    const secure = process.env.NODE_ENV === 'production' ? '; Secure' : '';
+    appendSetCookie(res, `${GOOGLE_STATE_COOKIE}=${encodeURIComponent(state)}; Max-Age=${GOOGLE_STATE_MAX_AGE_SECONDS}; Path=/; HttpOnly; SameSite=Lax${secure}`);
+}
+
+function clearGoogleStateCookie(res) {
+    const secure = process.env.NODE_ENV === 'production' ? '; Secure' : '';
+    appendSetCookie(res, `${GOOGLE_STATE_COOKIE}=; Max-Age=0; Path=/; HttpOnly; SameSite=Lax${secure}`);
 }
 
 function signSessionToken(user) {
@@ -189,11 +243,19 @@ function signSessionToken(user) {
 }
 
 function buildUserPayload(user) {
+    const authProviders = (user.authProviders || []).map((provider) => ({
+        provider: provider.provider,
+        email: provider.email,
+        linkedAt: provider.linkedAt
+    }));
+
     return {
         id: user._id,
         username: user.username,
         email: user.email,
         emailVerified: Boolean(user.emailVerified),
+        authProviders,
+        googleLinked: authProviders.some((provider) => provider.provider === GOOGLE_PROVIDER),
         displayName: user.displayName,
         avatar: user.avatar,
         role: user.role,
@@ -241,6 +303,30 @@ module.exports = async function handler(req, res) {
                 }
                 return await handleSignup(req, res);
             
+            case 'google-start':
+                if (req.method !== 'GET') {
+                    return res.status(405).json({ success: false, error: 'Method not allowed' });
+                }
+                return await handleGoogleStart(req, res, 'login');
+
+            case 'google-callback':
+                if (req.method !== 'GET') {
+                    return res.status(405).json({ success: false, error: 'Method not allowed' });
+                }
+                return await handleGoogleCallback(req, res);
+
+            case 'link-google':
+                if (req.method !== 'GET') {
+                    return res.status(405).json({ success: false, error: 'Method not allowed' });
+                }
+                return await handleGoogleStart(req, res, 'link');
+
+            case 'unlink-google':
+                if (req.method !== 'POST') {
+                    return res.status(405).json({ success: false, error: 'Method not allowed' });
+                }
+                return await handleUnlinkGoogle(req, res);
+
             case 'verify-email':
                 if (req.method !== 'GET' && req.method !== 'POST') {
                     return res.status(405).json({ success: false, error: 'Method not allowed' });
@@ -310,6 +396,320 @@ module.exports = async function handler(req, res) {
     }
 };
 
+
+function getGoogleConfig(req) {
+    const clientId = process.env.GOOGLE_CLIENT_ID;
+    const clientSecret = process.env.GOOGLE_CLIENT_SECRET;
+    const redirectUri = process.env.GOOGLE_REDIRECT_URI || `${getBaseUrl(req)}/api/auth?action=google-callback`;
+
+    if (!clientId || !clientSecret) {
+        return null;
+    }
+
+    return { clientId, clientSecret, redirectUri };
+}
+
+function encodeGoogleState(payload) {
+    return Buffer.from(JSON.stringify(payload)).toString('base64url');
+}
+
+function decodeGoogleState(value) {
+    try {
+        return JSON.parse(Buffer.from(String(value || ''), 'base64url').toString('utf8'));
+    } catch (_err) {
+        return null;
+    }
+}
+
+function getAuthenticatedUserFromRequest(req) {
+    const token = getRequestToken(req);
+    if (!token) return null;
+
+    try {
+        const decoded = jwt.verify(token, JWT_SECRET);
+        return { id: decoded.userId, username: decoded.username };
+    } catch (_err) {
+        return null;
+    }
+}
+
+function findLinkedProvider(user, provider = GOOGLE_PROVIDER) {
+    return (user.authProviders || []).find((authProvider) => authProvider.provider === provider);
+}
+
+function addOrUpdateGoogleProvider(user, googleProfile) {
+    if (!user.authProviders) user.authProviders = [];
+
+    const linkedProvider = findLinkedProvider(user);
+    if (linkedProvider) {
+        linkedProvider.providerUserId = googleProfile.sub;
+        linkedProvider.email = googleProfile.email;
+        linkedProvider.linkedAt = linkedProvider.linkedAt || new Date();
+        return;
+    }
+
+    user.authProviders.push({
+        provider: GOOGLE_PROVIDER,
+        providerUserId: googleProfile.sub,
+        email: googleProfile.email,
+        linkedAt: new Date()
+    });
+}
+
+async function buildUniqueUsername(googleProfile) {
+    const emailPrefix = String(googleProfile.email || '').split('@')[0];
+    const namePrefix = String(googleProfile.name || '').replace(/[^a-zA-Z0-9_]/g, '').slice(0, 20);
+    const base = (emailPrefix || namePrefix || 'google_user')
+        .replace(/[^a-zA-Z0-9_]/g, '_')
+        .replace(/_+/g, '_')
+        .replace(/^_+|_+$/g, '')
+        .slice(0, 16) || 'google_user';
+    const normalizedBase = base.length >= 3 ? base : `${base}_abs`;
+
+    for (let index = 0; index < 50; index += 1) {
+        const suffix = index === 0 ? '' : String(index);
+        const candidate = `${normalizedBase}${suffix}`.slice(0, 20);
+        const exists = await User.exists({ username: { $regex: new RegExp(`^${candidate.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`, 'i') } });
+        if (!exists) return candidate;
+    }
+
+    return `google_${crypto.randomBytes(5).toString('hex')}`.slice(0, 20);
+}
+
+async function fetchGoogleProfile(req, code) {
+    const googleConfig = getGoogleConfig(req);
+    if (!googleConfig) {
+        throw new Error('Google OAuth is not configured.');
+    }
+
+    const tokenResponse = await fetch('https://oauth2.googleapis.com/token', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({
+            code,
+            client_id: googleConfig.clientId,
+            client_secret: googleConfig.clientSecret,
+            redirect_uri: googleConfig.redirectUri,
+            grant_type: 'authorization_code'
+        })
+    });
+
+    if (!tokenResponse.ok) {
+        throw new Error('Google token exchange failed.');
+    }
+
+    const tokenPayload = await tokenResponse.json();
+    const profileResponse = await fetch('https://www.googleapis.com/oauth2/v3/userinfo', {
+        headers: { Authorization: `Bearer ${tokenPayload.access_token}` }
+    });
+
+    if (!profileResponse.ok) {
+        throw new Error('Google profile fetch failed.');
+    }
+
+    const profile = await profileResponse.json();
+    if (!profile.sub || !profile.email) {
+        throw new Error('Google did not return the required profile details.');
+    }
+
+    return {
+        sub: String(profile.sub),
+        email: normalizeIdentifier(profile.email),
+        emailVerified: profile.email_verified === true || profile.email_verified === 'true',
+        name: profile.name || profile.email
+    };
+}
+
+async function handleGoogleStart(req, res, mode = 'login') {
+    const googleConfig = getGoogleConfig(req);
+    const returnTo = getSafeReturnPath(req.query.returnTo || req.headers.referer);
+
+    if (!googleConfig) {
+        return redirectTo(res, buildRedirectUrl(req, mode === 'link' ? '/profile' : '/login', {
+            google_error: 'not_configured',
+            message: 'Google sign-in is not configured yet.'
+        }));
+    }
+
+    const authUser = getAuthenticatedUserFromRequest(req);
+    if (mode === 'link' && !authUser) {
+        return redirectTo(res, buildRedirectUrl(req, '/login', {
+            google_error: 'login_required',
+            message: 'Log in before linking a Google account.',
+            returnTo: '/profile'
+        }));
+    }
+
+    const nonce = crypto.randomBytes(24).toString('hex');
+    const state = encodeGoogleState({
+        nonce,
+        mode,
+        returnTo: mode === 'link' ? '/profile' : returnTo,
+        userId: mode === 'link' ? authUser.id : null,
+        createdAt: Date.now()
+    });
+    setGoogleStateCookie(res, nonce);
+
+    const authUrl = new URL('https://accounts.google.com/o/oauth2/v2/auth');
+    authUrl.searchParams.set('client_id', googleConfig.clientId);
+    authUrl.searchParams.set('redirect_uri', googleConfig.redirectUri);
+    authUrl.searchParams.set('response_type', 'code');
+    authUrl.searchParams.set('scope', GOOGLE_OAUTH_SCOPES.join(' '));
+    authUrl.searchParams.set('state', state);
+    authUrl.searchParams.set('prompt', 'select_account');
+
+    return redirectTo(res, authUrl.toString());
+}
+
+function googleErrorRedirect(req, res, state, code, message) {
+    const destination = state?.mode === 'link' ? '/profile' : '/login';
+    return redirectTo(res, buildRedirectUrl(req, destination, {
+        google_error: code,
+        message
+    }));
+}
+
+async function handleGoogleCallback(req, res) {
+    const state = decodeGoogleState(req.query.state);
+    const expectedNonce = parseCookies(req)[GOOGLE_STATE_COOKIE];
+    clearGoogleStateCookie(res);
+
+    if (req.query.error) {
+        return googleErrorRedirect(req, res, state, 'cancelled', 'Google sign-in was cancelled.');
+    }
+
+    if (!state || !expectedNonce || state.nonce !== expectedNonce || Date.now() - Number(state.createdAt || 0) > GOOGLE_STATE_MAX_AGE_SECONDS * 1000) {
+        return googleErrorRedirect(req, res, state, 'invalid_state', 'Google sign-in expired. Please try again.');
+    }
+
+    try {
+        const googleProfile = await fetchGoogleProfile(req, String(req.query.code || ''));
+
+        if (!googleProfile.emailVerified) {
+            return googleErrorRedirect(req, res, state, 'unverified_email', 'Google did not verify this email address.');
+        }
+
+        const alreadyLinkedUser = await User.findOne({
+            authProviders: {
+                $elemMatch: {
+                    provider: GOOGLE_PROVIDER,
+                    providerUserId: googleProfile.sub
+                }
+            }
+        });
+
+        if (state.mode === 'link') {
+            const authUser = getAuthenticatedUserFromRequest(req);
+            if (!authUser || String(authUser.id) !== String(state.userId)) {
+                return googleErrorRedirect(req, res, state, 'login_required', 'Log in before linking a Google account.');
+            }
+
+            const currentUser = await User.findById(state.userId);
+            if (!currentUser) {
+                return googleErrorRedirect(req, res, state, 'login_required', 'Log in before linking a Google account.');
+            }
+
+            if (alreadyLinkedUser && String(alreadyLinkedUser._id) !== String(currentUser._id)) {
+                return googleErrorRedirect(req, res, state, 'already_linked', 'That Google account is already linked to another Animal Battle Stats account.');
+            }
+
+            addOrUpdateGoogleProvider(currentUser, googleProfile);
+            if (currentUser.email === googleProfile.email) currentUser.emailVerified = true;
+            await currentUser.save();
+
+            const token = signSessionToken(currentUser);
+            setAuthCookie(res, token);
+            return redirectTo(res, buildRedirectUrl(req, state.returnTo || '/profile', { google_linked: '1' }));
+        }
+
+        if (alreadyLinkedUser) {
+            alreadyLinkedUser.lastLogin = new Date();
+            await alreadyLinkedUser.save();
+            const token = signSessionToken(alreadyLinkedUser);
+            setAuthCookie(res, token);
+            await notifyDiscord('login', { username: alreadyLinkedUser.username }, req);
+            return redirectTo(res, getSafeReturnPath(state.returnTo));
+        }
+
+        const existingEmailUser = await User.findOne({ email: googleProfile.email });
+        if (existingEmailUser) {
+            if (GOOGLE_AUTO_LINK_VERIFIED_EMAILS && existingEmailUser.emailVerified && googleProfile.emailVerified) {
+                addOrUpdateGoogleProvider(existingEmailUser, googleProfile);
+                existingEmailUser.lastLogin = new Date();
+                await existingEmailUser.save();
+                const token = signSessionToken(existingEmailUser);
+                setAuthCookie(res, token);
+                return redirectTo(res, getSafeReturnPath(state.returnTo));
+            }
+
+            return googleErrorRedirect(
+                req,
+                res,
+                state,
+                'existing_account',
+                'An account already uses that email. Log in first, then use Link Google account from your profile.'
+            );
+        }
+
+        const username = await buildUniqueUsername(googleProfile);
+        const user = new User({
+            username,
+            email: googleProfile.email,
+            displayName: String(googleProfile.name || username).slice(0, 30),
+            emailVerified: true,
+            authProviders: [{
+                provider: GOOGLE_PROVIDER,
+                providerUserId: googleProfile.sub,
+                email: googleProfile.email,
+                linkedAt: new Date()
+            }]
+        });
+
+        await user.save();
+        const token = signSessionToken(user);
+        setAuthCookie(res, token);
+        await notifyDiscord('signup', { username: user.username }, req);
+        return redirectTo(res, getSafeReturnPath(state.returnTo));
+    } catch (error) {
+        console.error('Google OAuth callback error:', error);
+        return googleErrorRedirect(req, res, state, 'oauth_failed', 'Google sign-in failed. Please try again.');
+    }
+}
+
+async function handleUnlinkGoogle(req, res) {
+    const authUser = getAuthenticatedUserFromRequest(req);
+    if (!authUser) {
+        return res.status(401).json({ success: false, error: 'Authentication required' });
+    }
+
+    const user = await User.findById(authUser.id).select('+password');
+    if (!user) {
+        return res.status(404).json({ success: false, error: 'User not found' });
+    }
+
+    const hasPassword = Boolean(user.password);
+    if (!hasPassword) {
+        return res.status(400).json({
+            success: false,
+            error: 'Add a password to your account before unlinking Google.'
+        });
+    }
+
+    const originalCount = (user.authProviders || []).length;
+    user.authProviders = (user.authProviders || []).filter((provider) => provider.provider !== GOOGLE_PROVIDER);
+
+    if (user.authProviders.length === originalCount) {
+        return res.status(400).json({ success: false, error: 'No Google account is linked.' });
+    }
+
+    await user.save();
+    return res.status(200).json({
+        success: true,
+        message: 'Google account unlinked.',
+        data: { user: buildUserPayload(user) }
+    });
+}
+
 // ==================== LOGIN ====================
 async function handleLogin(req, res) {
     const { login, password } = req.body || {};
@@ -337,6 +737,14 @@ async function handleLogin(req, res) {
     if (!user) {
         recordFailedAttempt('login', req, normalizedLogin, LOGIN_LIMIT);
         return res.status(401).json({ success: false, error: 'Invalid credentials' });
+    }
+
+    if (!user.password) {
+        recordFailedAttempt('login', req, normalizedLogin, LOGIN_LIMIT);
+        return res.status(401).json({
+            success: false,
+            error: 'This account uses Google sign-in. Continue with Google or reset your password to add password login.'
+        });
     }
 
     const isMatch = await user.comparePassword(password);
@@ -590,6 +998,9 @@ async function handleGetProfile(req, res) {
                 id: user._id,
                 username: user.username,
                 email: user.email,
+                emailVerified: Boolean(user.emailVerified),
+                authProviders: buildUserPayload(user).authProviders,
+                googleLinked: buildUserPayload(user).googleLinked,
                 displayName: user.displayName,
                 avatar: user.avatar,
                 role: user.role,
@@ -759,6 +1170,9 @@ async function handleUpdateProfile(req, res) {
                 id: user._id,
                 username: user.username,
                 email: user.email,
+                emailVerified: Boolean(user.emailVerified),
+                authProviders: buildUserPayload(user).authProviders,
+                googleLinked: buildUserPayload(user).googleLinked,
                 displayName: user.displayName || user.username,
                 avatar: user.avatar,
                 role: user.role,

--- a/css/legacy.css
+++ b/css/legacy.css
@@ -18219,3 +18219,83 @@ body:has(#home-view.active-view) .shared-bottom-bar {
     color: #00d4ff;
     text-decoration: underline;
 }
+
+/* Google OAuth buttons and profile linking */
+.google-auth-btn {
+    width: 100%;
+    padding: 12px 24px;
+    background: #ffffff;
+    border: 1px solid rgba(255, 255, 255, 0.25);
+    border-radius: 24px;
+    color: #1f2937;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    font-size: 1rem;
+    font-weight: 700;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.google-auth-btn:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 8px 18px rgba(255, 255, 255, 0.14);
+}
+
+.google-auth-btn .fa-google {
+    color: #4285f4;
+}
+
+.modal-google {
+    margin-top: 12px;
+    background: #ffffff !important;
+    color: #1f2937 !important;
+}
+
+.abs-google-link-group {
+    padding-top: 14px;
+    border-top: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.abs-google-link-row {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 12px;
+}
+
+.abs-google-status {
+    padding: 8px 12px;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 999px;
+    color: var(--text-muted);
+    background: rgba(255, 255, 255, 0.04);
+    font-family: var(--font-body);
+    font-size: 0.85rem;
+}
+
+.abs-google-status.linked {
+    color: #86efac;
+    border-color: rgba(34, 197, 94, 0.35);
+    background: rgba(34, 197, 94, 0.1);
+}
+
+.abs-google-btn {
+    width: auto;
+}
+
+.abs-google-btn.danger {
+    border-color: rgba(239, 68, 68, 0.45);
+    background: linear-gradient(180deg, rgba(160, 40, 40, 0.85) 0%, rgba(120, 25, 25, 0.95) 100%);
+}
+
+.abs-google-error {
+    display: none;
+    margin-top: 10px;
+    color: #fca5a5;
+    font-family: var(--font-body);
+    font-size: 0.85rem;
+    font-weight: 700;
+}

--- a/index.html
+++ b/index.html
@@ -438,6 +438,14 @@
                         
                         <div class="auth-page-error" id="login-page-error"></div>
                         
+                        <button type="button" class="google-auth-btn" data-google-auth="login">
+                            <i class="fab fa-google"></i> Continue with Google
+                        </button>
+
+                        <div class="auth-page-divider">
+                            <span>or</span>
+                        </div>
+
                         <form class="auth-page-form" id="login-page-form">
                             <div class="auth-form-group">
                                 <label for="login-page-email">Email or username</label>
@@ -457,10 +465,6 @@
 
                         <div class="auth-page-switch">
                             <a href="/forgot-password">Forgot your password?</a>
-                        </div>
-                        
-                        <div class="auth-page-divider">
-                            <span>or</span>
                         </div>
                         
                         <div class="auth-page-switch">
@@ -571,6 +575,14 @@
                         
                         <div class="auth-page-error" id="signup-page-error"></div>
                         
+                        <button type="button" class="google-auth-btn" data-google-auth="signup">
+                            <i class="fab fa-google"></i> Continue with Google
+                        </button>
+
+                        <div class="auth-page-divider">
+                            <span>or</span>
+                        </div>
+
                         <form class="auth-page-form" id="signup-page-form">
                             <div class="auth-form-group">
                                 <label for="signup-page-username">Username</label>
@@ -596,10 +608,6 @@
                                 <span class="btn-loader"><i class="fas fa-spinner fa-spin"></i></span>
                             </button>
                         </form>
-                        
-                        <div class="auth-page-divider">
-                            <span>or</span>
-                        </div>
                         
                         <div class="auth-page-switch">
                             Already on Animal Battle Stats? <a href="/login">Sign in</a>
@@ -770,6 +778,20 @@
                                         <label for="retro-username">Username</label>
                                         <p class="abs-form-hint">Your login username. <span id="retro-username-changes">3 changes remaining this week.</span></p>
                                         <input type="text" id="retro-username" placeholder="Enter username..." maxlength="20">
+                                    </div>
+                                    <div class="abs-form-group abs-google-link-group">
+                                        <label>Google account</label>
+                                        <p class="abs-form-hint">Use Google to sign in faster while keeping this Animal Battle Stats profile.</p>
+                                        <div class="abs-google-link-row">
+                                            <span class="abs-google-status" id="google-link-status">Not linked</span>
+                                            <button type="button" class="abs-save-btn abs-google-btn" id="link-google-btn">
+                                                <i class="fab fa-google"></i> Link Google account
+                                            </button>
+                                            <button type="button" class="abs-save-btn abs-google-btn danger" id="unlink-google-btn" style="display: none;">
+                                                <i class="fab fa-google"></i> Unlink Google
+                                            </button>
+                                        </div>
+                                        <div class="abs-google-error" id="google-link-error"></div>
                                     </div>
                                     <div class="abs-form-actions">
                                         <span class="abs-unsaved-indicator" id="retro-unsaved-indicator">
@@ -1979,6 +2001,9 @@
                     <span class="btn-text">LOG IN</span>
                     <span class="btn-loader" style="display: none;"><i class="fas fa-spinner fa-spin"></i></span>
                 </button>
+                <button type="button" class="auth-submit-btn google-auth-btn modal-google" data-google-auth="modal-login">
+                    <i class="fab fa-google"></i> Continue with Google
+                </button>
                 <div class="auth-switch">
                     <a href="#" id="show-forgot">Forgot your password?</a>
                 </div>
@@ -2010,6 +2035,9 @@
                 <button class="auth-submit-btn" id="signup-submit">
                     <span class="btn-text">CREATE ACCOUNT</span>
                     <span class="btn-loader" style="display: none;"><i class="fas fa-spinner fa-spin"></i></span>
+                </button>
+                <button type="button" class="auth-submit-btn google-auth-btn modal-google" data-google-auth="modal-signup">
+                    <i class="fab fa-google"></i> Continue with Google
                 </button>
                 <div class="auth-switch">
                     Already have an account? <a href="#" id="show-login">Log in</a>

--- a/js/auth.js
+++ b/js/auth.js
@@ -39,6 +39,7 @@ const Auth = {
         this.bindEvents();
         this.bindPageEvents();
         this.bindCloseButtons();
+        this.handleGoogleRedirectMessage();
         this.installRenameNavigationGuard();
         this.checkExistingSession();
     },
@@ -113,7 +114,12 @@ const Auth = {
             avatarPreviewCurrent: document.getElementById('avatar-preview-current'),
             avatarPreviewName: document.getElementById('avatar-preview-name'),
             avatarSaveBtn: document.getElementById('avatar-save-btn'),
-            avatarCancelBtn: document.getElementById('avatar-cancel-btn')
+            avatarCancelBtn: document.getElementById('avatar-cancel-btn'),
+            googleLoginButtons: document.querySelectorAll('[data-google-auth]'),
+            linkGoogleBtn: document.getElementById('link-google-btn'),
+            unlinkGoogleBtn: document.getElementById('unlink-google-btn'),
+            googleLinkStatus: document.getElementById('google-link-status'),
+            googleLinkError: document.getElementById('google-link-error')
         };
     },
 
@@ -151,6 +157,11 @@ const Auth = {
         });
 
         // Submit forms
+        this.elements.googleLoginButtons?.forEach((button) => {
+            button.addEventListener('click', () => this.startGoogleAuth());
+        });
+        this.elements.linkGoogleBtn?.addEventListener('click', () => this.startGoogleLink());
+        this.elements.unlinkGoogleBtn?.addEventListener('click', () => this.unlinkGoogle());
         this.elements.loginSubmit?.addEventListener('click', () => this.handleLogin());
         this.elements.signupSubmit?.addEventListener('click', () => this.handleSignup());
         this.elements.forgotSubmit?.addEventListener('click', () => this.handleForgotPassword('modal'));
@@ -576,6 +587,114 @@ const Auth = {
         } finally {
             isPage ? this.setPageLoading('reset', false) : this.setLoading('reset', false);
         }
+    },
+
+    startGoogleAuth() {
+        const returnTo = window.location.pathname && !['/login', '/signup'].includes(window.location.pathname)
+            ? window.location.pathname
+            : '/';
+        window.location.href = `/api/auth?action=google-start&returnTo=${encodeURIComponent(returnTo)}`;
+    },
+
+    startGoogleLink() {
+        if (!this.isLoggedIn()) {
+            this.showToast('Log in before linking Google.');
+            this.showModal('login');
+            return;
+        }
+        window.location.href = '/api/auth?action=link-google';
+    },
+
+    async unlinkGoogle() {
+        if (!this.token) return;
+
+        const button = this.elements.unlinkGoogleBtn;
+        if (button) {
+            button.disabled = true;
+            button.innerHTML = '<i class="fas fa-spinner fa-spin"></i> Unlinking...';
+        }
+
+        try {
+            const response = await fetch('/api/auth?action=unlink-google', {
+                method: 'POST',
+                headers: { Authorization: `Bearer ${this.token}` },
+                credentials: 'same-origin'
+            });
+            const result = await response.json();
+
+            if (result.success) {
+                this.user = { ...this.user, ...result.data.user };
+                this.updateGoogleLinkUI();
+                this.showToast(result.message || 'Google account unlinked.');
+            } else {
+                this.showGoogleLinkError(result.error || 'Unable to unlink Google.');
+            }
+        } catch (error) {
+            console.error('Google unlink error:', error);
+            this.showGoogleLinkError('Network error. Please try again.');
+        } finally {
+            if (button) {
+                button.disabled = false;
+                button.innerHTML = '<i class="fab fa-google"></i> Unlink Google';
+            }
+        }
+    },
+
+    handleGoogleRedirectMessage() {
+        const params = new URLSearchParams(window.location.search);
+        const googleError = params.get('google_error');
+        const googleLinked = params.get('google_linked');
+        const message = params.get('message');
+
+        if (!googleError && !googleLinked) return;
+
+        const cleanUrl = `${window.location.pathname}${window.location.hash || ''}`;
+        window.history.replaceState({}, document.title, cleanUrl);
+
+        if (googleError) {
+            const fallbackMessages = {
+                already_linked: 'That Google account is already linked to another account.',
+                existing_account: 'An account already uses that email. Log in first, then link Google from your profile.',
+                login_required: 'Log in before linking a Google account.',
+                not_configured: 'Google sign-in is not configured yet.',
+                invalid_state: 'Google sign-in expired. Please try again.',
+                unverified_email: 'Google did not verify this email address.',
+                oauth_failed: 'Google sign-in failed. Please try again.',
+                cancelled: 'Google sign-in was cancelled.'
+            };
+            const text = message || fallbackMessages[googleError] || 'Google sign-in failed. Please try again.';
+            this.showPageError(window.location.pathname === '/signup' ? 'signup' : 'login', text);
+            this.showGoogleLinkError(text);
+            this.showToast(text, 5000);
+        } else if (googleLinked) {
+            this.showToast('Google account linked successfully.');
+        }
+    },
+
+    showGoogleLinkError(message) {
+        if (this.elements.googleLinkError) {
+            this.elements.googleLinkError.textContent = message;
+            this.elements.googleLinkError.style.display = message ? 'block' : 'none';
+        }
+    },
+
+    updateGoogleLinkUI() {
+        const linkedProvider = (this.user?.authProviders || []).find((provider) => provider.provider === 'google');
+        const isLinked = Boolean(this.user?.googleLinked || linkedProvider);
+
+        if (this.elements.googleLinkStatus) {
+            this.elements.googleLinkStatus.textContent = isLinked
+                ? `Linked${linkedProvider?.email ? ` to ${linkedProvider.email}` : ''}`
+                : 'Not linked';
+            this.elements.googleLinkStatus.classList.toggle('linked', isLinked);
+        }
+        if (this.elements.linkGoogleBtn) {
+            this.elements.linkGoogleBtn.style.display = isLinked ? 'none' : 'inline-flex';
+        }
+        if (this.elements.unlinkGoogleBtn) {
+            this.elements.unlinkGoogleBtn.style.display = isLinked ? 'inline-flex' : 'none';
+        }
+        this.showGoogleLinkError('');
     },
 
     /**
@@ -1040,6 +1159,7 @@ const Auth = {
             
             // Update user stats bar
             this.updateUserStatsBar();
+            this.updateGoogleLinkUI();
         } else {
             // Show login button, hide stats bar
             if (this.elements.authLoginBtn) {
@@ -1056,6 +1176,7 @@ const Auth = {
             if (homeProfileLink) {
                 homeProfileLink.style.display = 'none';
             }
+            this.updateGoogleLinkUI();
         }
     },
 
@@ -1348,6 +1469,7 @@ const Auth = {
 
         // Reset save button state
         this.updateSaveButtonState();
+        this.updateGoogleLinkUI();
     },
 
     /**

--- a/lib/models/User.js
+++ b/lib/models/User.js
@@ -6,6 +6,27 @@
 const mongoose = require('mongoose');
 const bcrypt = require('bcryptjs');
 
+const AuthProviderSchema = new mongoose.Schema({
+    provider: {
+        type: String,
+        required: true,
+        enum: ['google']
+    },
+    providerUserId: {
+        type: String,
+        required: true
+    },
+    email: {
+        type: String,
+        trim: true,
+        lowercase: true
+    },
+    linkedAt: {
+        type: Date,
+        default: Date.now
+    }
+}, { _id: false });
+
 const UserSchema = new mongoose.Schema({
     username: {
         type: String,
@@ -26,7 +47,12 @@ const UserSchema = new mongoose.Schema({
     },
     password: {
         type: String,
-        required: [true, 'Password is required'],
+        required: [
+            function passwordRequired() {
+                return !this.authProviders || this.authProviders.length === 0;
+            },
+            'Password is required'
+        ],
         minlength: [8, 'Password must be at least 8 characters'],
         select: false // Don't include password in queries by default
     },
@@ -47,6 +73,10 @@ const UserSchema = new mongoose.Schema({
     emailVerified: {
         type: Boolean,
         default: false
+    },
+    authProviders: {
+        type: [AuthProviderSchema],
+        default: []
     },
     emailVerificationTokenHash: {
         type: String,
@@ -155,6 +185,8 @@ const UserSchema = new mongoose.Schema({
 }, {
     timestamps: true
 });
+
+UserSchema.index({ 'authProviders.provider': 1, 'authProviders.providerUserId': 1 }, { unique: true, sparse: true });
 
 // Hash password before saving
 UserSchema.pre('save', async function(next) {


### PR DESCRIPTION
### Motivation
- Add Google sign-in and account linking so users can authenticate with Google and optionally link a Google account to an existing profile. 
- Support Google-only accounts while preserving existing password-based flows and enforce safe linking when an email already exists. 

### Description
- Extended the user model with an `authProviders` array (schema: `provider, providerUserId, email, linkedAt`), a unique provider index, and a conditional password requirement allowing Google-only accounts (file: `lib/models/User.js`).
- Implemented Google OAuth endpoints and flow in the consolidated auth route: `/api/auth?action=google-start`, `/api/auth?action=google-callback`, `/api/auth?action=link-google`, and `/api/auth?action=unlink-google`, including state cookie CSRF protection, token exchange, profile fetch, account creation, linking/unlinking, and safe redirect handling (file: `api/auth.js`).
- Enforced linking policy: when Google returns an email that matches an existing account, require the existing user to sign in first before linking unless `GOOGLE_AUTO_LINK_VERIFIED_EMAILS=true` and both emails are verified (file: `api/auth.js`).
- Frontend additions: "Continue with Google" buttons on login/signup and in the auth modal, profile controls to `Link/Unlink Google`, client-side handlers to start/link/unlink flows, and redirect/error handling for OAuth outcomes (files: `index.html`, `js/auth.js`).
- Added styles for Google buttons and profile link UI (file: `css/legacy.css`).

### Testing
- Ran linting with `npm run lint` and it completed successfully.
- Performed syntax checks with `node -c api/auth.js`, `node -c lib/models/User.js`, and `node -c js/auth.js`, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0051d6a42c8320b724a6b884a8508c)