### PR TITLE
Add email notification preferences, weekly digest, and unsubscribe flow

### DIFF
--- a/api/auth.js
+++ b/api/auth.js
@@ -12,6 +12,8 @@
  * GET /api/auth?action=google-callback - Complete Google OAuth sign in
  * GET /api/auth?action=link-google - Begin linking Google to the current user
  * POST /api/auth?action=unlink-google - Unlink Google from the current user
+ * GET/PUT /api/auth?action=notification-preferences - Manage email notification settings
+ * GET /api/auth?action=unsubscribe - Public signed-token email unsubscribe
  */
 
 const { connectToDatabase } = require('../lib/mongodb');
@@ -21,6 +23,11 @@ const crypto = require('crypto');
 const { notifyDiscord } = require('../lib/discord');
 const { verifyToken, JWT_SECRET } = require('../lib/auth');
 const { validatePublicName } = require('../lib/moderation');
+const {
+    normalizeNotificationPreferences,
+    sendEmail,
+    verifyUnsubscribeToken
+} = require('../lib/email');
 const { 
     XP_REWARDS, 
     xpToNext, 
@@ -124,26 +131,9 @@ function getBaseUrl(req) {
     return `${protocol}://${req.headers.host}`;
 }
 
-async function sendAuthEmail({ to, subject, text, html }) {
-    if (process.env.AUTH_EMAIL_WEBHOOK_URL) {
-        try {
-            await fetch(process.env.AUTH_EMAIL_WEBHOOK_URL, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ to, subject, text, html })
-            });
-            return;
-        } catch (error) {
-            console.error('Auth email webhook failed:', error);
-        }
-    }
-
-    console.info('Auth email queued (configure AUTH_EMAIL_WEBHOOK_URL to send):', { to, subject, text });
-}
-
 async function sendVerificationEmail(req, user, token) {
     const url = `${getBaseUrl(req)}/api/auth?action=verify-email&email=${encodeURIComponent(user.email)}&token=${encodeURIComponent(token)}`;
-    await sendAuthEmail({
+    await sendEmail({
         to: user.email,
         subject: 'Verify your Animal Battle Stats email',
         text: `Verify your email by opening this link: ${url}`,
@@ -153,7 +143,7 @@ async function sendVerificationEmail(req, user, token) {
 
 async function sendPasswordResetEmail(req, user, token) {
     const url = `${getBaseUrl(req)}/reset-password?email=${encodeURIComponent(user.email)}&token=${encodeURIComponent(token)}`;
-    await sendAuthEmail({
+    await sendEmail({
         to: user.email,
         subject: 'Reset your Animal Battle Stats password',
         text: `Reset your password by opening this link: ${url}. This link expires in ${RESET_TOKEN_MINUTES} minutes.`,
@@ -254,6 +244,7 @@ function buildUserPayload(user) {
         username: user.username,
         email: user.email,
         emailVerified: Boolean(user.emailVerified),
+        emailNotifications: normalizeNotificationPreferences(user.emailNotifications || {}),
         authProviders,
         googleLinked: authProviders.some((provider) => provider.provider === GOOGLE_PROVIDER),
         displayName: user.displayName,
@@ -365,6 +356,20 @@ module.exports = async function handler(req, res) {
                     return await handleUpdateProfile(req, res);
                 }
                 return res.status(405).json({ success: false, error: 'Method not allowed' });
+
+            case 'notification-preferences':
+                if (req.method === 'GET') {
+                    return await handleGetNotificationPreferences(req, res);
+                } else if (req.method === 'PUT') {
+                    return await handleUpdateNotificationPreferences(req, res);
+                }
+                return res.status(405).json({ success: false, error: 'Method not allowed' });
+
+            case 'unsubscribe':
+                if (req.method !== 'GET' && req.method !== 'POST') {
+                    return res.status(405).json({ success: false, error: 'Method not allowed' });
+                }
+                return await handleUnsubscribe(req, res);
             
             case 'rewards':
                 return await handleRewards(req, res);
@@ -938,6 +943,120 @@ async function handleResetPassword(req, res) {
     return res.status(200).json({ success: true, message: 'Password reset successfully. Please sign in with your new password.' });
 }
 
+
+function getAuthenticatedRequestUser(req) {
+    const token = getRequestToken(req);
+    if (!token) return null;
+
+    try {
+        const decoded = jwt.verify(token, JWT_SECRET);
+        return { id: decoded.userId, username: decoded.username };
+    } catch (_err) {
+        return null;
+    }
+}
+
+function pickNotificationPreferenceUpdates(body = {}) {
+    const allowedKeys = ['enabled', 'weeklyDigest', 'newFeatures', 'commentReplies', 'tournamentUpdates'];
+    const updates = {};
+
+    allowedKeys.forEach((key) => {
+        if (Object.prototype.hasOwnProperty.call(body, key)) {
+            updates[key] = Boolean(body[key]);
+        }
+    });
+
+    return updates;
+}
+
+// ==================== NOTIFICATION PREFERENCES ====================
+async function handleGetNotificationPreferences(req, res) {
+    const authUser = getAuthenticatedRequestUser(req);
+    if (!authUser) {
+        return res.status(401).json({ success: false, error: 'Authentication required' });
+    }
+
+    const user = await User.findById(authUser.id);
+    if (!user) {
+        return res.status(404).json({ success: false, error: 'User not found' });
+    }
+
+    return res.status(200).json({
+        success: true,
+        data: {
+            emailNotifications: normalizeNotificationPreferences(user.emailNotifications || {})
+        }
+    });
+}
+
+async function handleUpdateNotificationPreferences(req, res) {
+    const authUser = getAuthenticatedRequestUser(req);
+    if (!authUser) {
+        return res.status(401).json({ success: false, error: 'Authentication required' });
+    }
+
+    const user = await User.findById(authUser.id);
+    if (!user) {
+        return res.status(404).json({ success: false, error: 'User not found' });
+    }
+
+    const current = normalizeNotificationPreferences(user.emailNotifications || {});
+    const updates = pickNotificationPreferenceUpdates(req.body || {});
+    const next = { ...current, ...updates };
+
+    if (Object.prototype.hasOwnProperty.call(updates, 'enabled')) {
+        next.unsubscribedAt = updates.enabled ? null : (current.unsubscribedAt || new Date());
+    } else if (next.enabled && current.unsubscribedAt) {
+        next.unsubscribedAt = null;
+    }
+
+    user.emailNotifications = next;
+    await user.save();
+
+    return res.status(200).json({
+        success: true,
+        message: 'Notification preferences updated',
+        data: {
+            emailNotifications: normalizeNotificationPreferences(user.emailNotifications || {})
+        }
+    });
+}
+
+// ==================== PUBLIC UNSUBSCRIBE ====================
+async function handleUnsubscribe(req, res) {
+    const token = String(req.query.token || req.body?.token || '');
+    const payload = verifyUnsubscribeToken(token);
+
+    if (!payload?.userId || !payload?.email) {
+        return res.status(400).json({ success: false, error: 'Unsubscribe link is invalid.' });
+    }
+
+    const user = await User.findOne({ _id: payload.userId, email: normalizeIdentifier(payload.email) });
+    if (!user) {
+        return res.status(404).json({ success: false, error: 'User not found.' });
+    }
+
+    const preferences = normalizeNotificationPreferences(user.emailNotifications || {});
+    preferences.enabled = false;
+    preferences.weeklyDigest = false;
+    preferences.newFeatures = false;
+    preferences.commentReplies = false;
+    preferences.tournamentUpdates = false;
+    preferences.unsubscribedAt = new Date();
+    user.emailNotifications = preferences;
+    await user.save();
+
+    if (req.method === 'GET' && !(req.headers.accept || '').includes('application/json')) {
+        res.setHeader('Content-Type', 'text/html; charset=utf-8');
+        return res.status(200).send('<!doctype html><html><head><title>Unsubscribed</title></head><body><h1>You are unsubscribed</h1><p>You will no longer receive Animal Battle Stats notification emails.</p><p>You can opt back in from your profile settings.</p></body></html>');
+    }
+
+    return res.status(200).json({
+        success: true,
+        message: 'You have been unsubscribed from notification emails.'
+    });
+}
+
 // ==================== ME ====================
 async function handleMe(req, res) {
     const token = getRequestToken(req);
@@ -999,6 +1118,7 @@ async function handleGetProfile(req, res) {
                 username: user.username,
                 email: user.email,
                 emailVerified: Boolean(user.emailVerified),
+                emailNotifications: normalizeNotificationPreferences(user.emailNotifications || {}),
                 authProviders: buildUserPayload(user).authProviders,
                 googleLinked: buildUserPayload(user).googleLinked,
                 displayName: user.displayName,
@@ -1171,6 +1291,7 @@ async function handleUpdateProfile(req, res) {
                 username: user.username,
                 email: user.email,
                 emailVerified: Boolean(user.emailVerified),
+                emailNotifications: normalizeNotificationPreferences(user.emailNotifications || {}),
                 authProviders: buildUserPayload(user).authProviders,
                 googleLinked: buildUserPayload(user).googleLinked,
                 displayName: user.displayName || user.username,

--- a/index.html
+++ b/index.html
@@ -793,6 +793,36 @@
                                         </div>
                                         <div class="abs-google-error" id="google-link-error"></div>
                                     </div>
+                                    <div class="abs-form-group abs-notification-group">
+                                        <label>Email notifications</label>
+                                        <p class="abs-form-hint">Choose which Animal Battle Stats updates can reach your inbox. You can unsubscribe any time.</p>
+                                        <div class="abs-notification-options" id="notification-preferences-form">
+                                            <label class="checkbox-option">
+                                                <input type="checkbox" id="email-notifications-enabled" data-notification-key="enabled">
+                                                <span>Enable email notifications</span>
+                                            </label>
+                                            <label class="checkbox-option">
+                                                <input type="checkbox" id="email-notifications-weekly" data-notification-key="weeklyDigest">
+                                                <span>Weekly digest: new animals, rankings, replies, XP/BP, tournaments, and community highlights</span>
+                                            </label>
+                                            <label class="checkbox-option">
+                                                <input type="checkbox" id="email-notifications-features" data-notification-key="newFeatures">
+                                                <span>New feature announcements</span>
+                                            </label>
+                                            <label class="checkbox-option">
+                                                <input type="checkbox" id="email-notifications-replies" data-notification-key="commentReplies">
+                                                <span>Replies to my comments</span>
+                                            </label>
+                                            <label class="checkbox-option">
+                                                <input type="checkbox" id="email-notifications-tournaments" data-notification-key="tournamentUpdates">
+                                                <span>Tournament updates and community events</span>
+                                            </label>
+                                        </div>
+                                        <p class="abs-form-hint" id="email-notifications-status" aria-live="polite"></p>
+                                        <button type="button" class="abs-save-btn" id="email-notifications-save" disabled>
+                                            <i class="fas fa-envelope"></i> Save Email Preferences
+                                        </button>
+                                    </div>
                                     <div class="abs-form-actions">
                                         <span class="abs-unsaved-indicator" id="retro-unsaved-indicator">
                                             <i class="fas fa-exclamation-circle"></i> Unsaved changes

--- a/js/auth.js
+++ b/js/auth.js
@@ -24,6 +24,8 @@ const Auth = {
         profileAnimal: null
     },
 
+    originalNotificationPreferences: null,
+
     // DOM Elements
     elements: {},
 
@@ -119,7 +121,15 @@ const Auth = {
             linkGoogleBtn: document.getElementById('link-google-btn'),
             unlinkGoogleBtn: document.getElementById('unlink-google-btn'),
             googleLinkStatus: document.getElementById('google-link-status'),
-            googleLinkError: document.getElementById('google-link-error')
+            googleLinkError: document.getElementById('google-link-error'),
+            notificationPreferencesForm: document.getElementById('notification-preferences-form'),
+            notificationEnabled: document.getElementById('email-notifications-enabled'),
+            notificationWeeklyDigest: document.getElementById('email-notifications-weekly'),
+            notificationNewFeatures: document.getElementById('email-notifications-features'),
+            notificationCommentReplies: document.getElementById('email-notifications-replies'),
+            notificationTournamentUpdates: document.getElementById('email-notifications-tournaments'),
+            notificationStatus: document.getElementById('email-notifications-status'),
+            notificationSaveBtn: document.getElementById('email-notifications-save')
         };
     },
 
@@ -162,6 +172,10 @@ const Auth = {
         });
         this.elements.linkGoogleBtn?.addEventListener('click', () => this.startGoogleLink());
         this.elements.unlinkGoogleBtn?.addEventListener('click', () => this.unlinkGoogle());
+        this.elements.notificationPreferencesForm?.querySelectorAll('[data-notification-key]').forEach((input) => {
+            input.addEventListener('change', () => this.handleNotificationPreferenceChange());
+        });
+        this.elements.notificationSaveBtn?.addEventListener('click', () => this.saveNotificationPreferences());
         this.elements.loginSubmit?.addEventListener('click', () => this.handleLogin());
         this.elements.signupSubmit?.addEventListener('click', () => this.handleSignup());
         this.elements.forgotSubmit?.addEventListener('click', () => this.handleForgotPassword('modal'));
@@ -1444,6 +1458,7 @@ const Auth = {
 
         // Fetch fresh profile data
         await this.fetchProfile();
+        await this.fetchNotificationPreferences();
 
         // Store original values for change detection
         this.originalValues = {
@@ -1451,6 +1466,7 @@ const Auth = {
             username: this.user.username || '',
             profileAnimal: this.user.profileAnimal || null
         };
+        this.originalNotificationPreferences = this.normalizeNotificationPreferences(this.user.emailNotifications || {});
 
         // Reset pending changes
         this.pendingChanges = {
@@ -1466,6 +1482,7 @@ const Auth = {
         if (this.elements.retroUsername) {
             this.elements.retroUsername.value = this.user.username || '';
         }
+        this.populateNotificationPreferences();
 
         // Reset save button state
         this.updateSaveButtonState();
@@ -1527,6 +1544,154 @@ const Auth = {
         
         if (this.elements.avatarPreviewName) {
             this.elements.avatarPreviewName.textContent = animal?.name || 'None';
+        }
+    },
+
+
+    normalizeNotificationPreferences(preferences = {}) {
+        return {
+            enabled: Boolean(preferences.enabled),
+            weeklyDigest: Boolean(preferences.weeklyDigest),
+            newFeatures: Boolean(preferences.newFeatures),
+            commentReplies: Boolean(preferences.commentReplies),
+            tournamentUpdates: Boolean(preferences.tournamentUpdates),
+            unsubscribedAt: preferences.unsubscribedAt || null
+        };
+    },
+
+    getNotificationPreferenceInputs() {
+        return {
+            enabled: this.elements.notificationEnabled,
+            weeklyDigest: this.elements.notificationWeeklyDigest,
+            newFeatures: this.elements.notificationNewFeatures,
+            commentReplies: this.elements.notificationCommentReplies,
+            tournamentUpdates: this.elements.notificationTournamentUpdates
+        };
+    },
+
+    getNotificationPreferencesFromForm() {
+        const inputs = this.getNotificationPreferenceInputs();
+        return {
+            enabled: Boolean(inputs.enabled?.checked),
+            weeklyDigest: Boolean(inputs.weeklyDigest?.checked),
+            newFeatures: Boolean(inputs.newFeatures?.checked),
+            commentReplies: Boolean(inputs.commentReplies?.checked),
+            tournamentUpdates: Boolean(inputs.tournamentUpdates?.checked)
+        };
+    },
+
+    populateNotificationPreferences() {
+        const preferences = this.normalizeNotificationPreferences(this.user?.emailNotifications || {});
+        this.originalNotificationPreferences = preferences;
+        const inputs = this.getNotificationPreferenceInputs();
+
+        Object.entries(inputs).forEach(([key, input]) => {
+            if (input) input.checked = Boolean(preferences[key]);
+        });
+
+        this.updateNotificationPreferenceState();
+    },
+
+    handleNotificationPreferenceChange() {
+        this.updateNotificationPreferenceState();
+    },
+
+    updateNotificationPreferenceState() {
+        const inputs = this.getNotificationPreferenceInputs();
+        const enabled = Boolean(inputs.enabled?.checked);
+
+        ['weeklyDigest', 'newFeatures', 'commentReplies', 'tournamentUpdates'].forEach((key) => {
+            if (inputs[key]) inputs[key].disabled = !enabled;
+        });
+
+        const current = this.getNotificationPreferencesFromForm();
+        const original = this.originalNotificationPreferences || this.normalizeNotificationPreferences();
+        const changed = ['enabled', 'weeklyDigest', 'newFeatures', 'commentReplies', 'tournamentUpdates']
+            .some((key) => Boolean(current[key]) !== Boolean(original[key]));
+
+        if (this.elements.notificationSaveBtn) {
+            this.elements.notificationSaveBtn.disabled = !changed;
+        }
+        if (this.elements.notificationStatus && !changed) {
+            const unsubscribedAt = original.unsubscribedAt ? new Date(original.unsubscribedAt).toLocaleDateString() : null;
+            this.elements.notificationStatus.textContent = unsubscribedAt
+                ? `Unsubscribed on ${unsubscribedAt}. Enable notifications to opt back in.`
+                : '';
+        }
+    },
+
+    async fetchNotificationPreferences() {
+        if (!this.token) return;
+
+        try {
+            const response = await fetch('/api/auth?action=notification-preferences', {
+                headers: {
+                    'Authorization': `Bearer ${this.token}`
+                },
+                credentials: 'same-origin'
+            });
+            const result = await response.json();
+            if (response.ok && result.success) {
+                this.user = {
+                    ...this.user,
+                    emailNotifications: result.data.emailNotifications
+                };
+                this.populateNotificationPreferences();
+            }
+        } catch (error) {
+            console.error('Notification preferences fetch error:', error);
+        }
+    },
+
+    async saveNotificationPreferences() {
+        if (!this.token) return;
+
+        const btn = this.elements.notificationSaveBtn;
+        const status = this.elements.notificationStatus;
+        const preferences = this.getNotificationPreferencesFromForm();
+
+        if (btn) {
+            btn.disabled = true;
+            btn.innerHTML = '<i class="fas fa-spinner fa-spin"></i> Saving...';
+        }
+        if (status) status.textContent = '';
+
+        try {
+            const response = await fetch('/api/auth?action=notification-preferences', {
+                method: 'PUT',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Authorization': `Bearer ${this.token}`
+                },
+                credentials: 'same-origin',
+                body: JSON.stringify(preferences)
+            });
+            const result = await response.json();
+
+            if (response.ok && result.success) {
+                this.user = {
+                    ...this.user,
+                    emailNotifications: result.data.emailNotifications
+                };
+                this.originalNotificationPreferences = this.normalizeNotificationPreferences(result.data.emailNotifications);
+                this.populateNotificationPreferences();
+                if (status) status.textContent = 'Email preferences saved.';
+                this.showToast('Email preferences saved!');
+            } else {
+                const message = result.error || 'Failed to save email preferences';
+                if (status) status.textContent = message;
+                this.showToast(message);
+                this.updateNotificationPreferenceState();
+            }
+        } catch (error) {
+            console.error('Notification preferences save error:', error);
+            if (status) status.textContent = 'Network error saving email preferences.';
+            this.showToast('Network error saving email preferences');
+            this.updateNotificationPreferenceState();
+        } finally {
+            if (btn) {
+                btn.innerHTML = '<i class="fas fa-envelope"></i> Save Email Preferences';
+            }
         }
     },
 

--- a/lib/email.js
+++ b/lib/email.js
@@ -1,0 +1,246 @@
+/**
+ * Email provider integration and notification email helpers.
+ *
+ * The default provider is webhook-based so production can point to SendGrid,
+ * Resend, Postmark, or another service without adding vendor-specific code to
+ * API routes. In local development, messages are logged instead of sent.
+ */
+
+const crypto = require('crypto');
+const Animal = require('./models/Animal');
+const BattleStats = require('./models/BattleStats');
+const Comment = require('./models/Comment');
+const RankHistory = require('./models/RankHistory');
+
+const EMAIL_WEBHOOK_URL = process.env.EMAIL_WEBHOOK_URL || process.env.AUTH_EMAIL_WEBHOOK_URL;
+const EMAIL_FROM = process.env.EMAIL_FROM || 'Animal Battle Stats <no-reply@animalbattlestats.com>';
+const UNSUBSCRIBE_SECRET = process.env.UNSUBSCRIBE_SECRET || process.env.JWT_SECRET;
+const DIGEST_LOOKBACK_DAYS = 7;
+
+function getDefaultNotificationPreferences() {
+    return {
+        enabled: false,
+        weeklyDigest: false,
+        newFeatures: false,
+        commentReplies: false,
+        tournamentUpdates: false,
+        unsubscribedAt: null
+    };
+}
+
+function normalizeNotificationPreferences(raw = {}) {
+    const defaults = getDefaultNotificationPreferences();
+    return {
+        enabled: Boolean(raw.enabled),
+        weeklyDigest: Boolean(raw.weeklyDigest),
+        newFeatures: Boolean(raw.newFeatures),
+        commentReplies: Boolean(raw.commentReplies),
+        tournamentUpdates: Boolean(raw.tournamentUpdates),
+        unsubscribedAt: raw.unsubscribedAt || defaults.unsubscribedAt
+    };
+}
+
+function preferencesAllowEmail(user, preferenceKey) {
+    const preferences = normalizeNotificationPreferences(user.emailNotifications || {});
+    return Boolean(preferences.enabled && preferences[preferenceKey] && !preferences.unsubscribedAt);
+}
+
+async function sendEmail({ to, subject, text, html, headers = {} }) {
+    const payload = {
+        from: EMAIL_FROM,
+        to,
+        subject,
+        text,
+        html,
+        headers
+    };
+
+    if (EMAIL_WEBHOOK_URL) {
+        const response = await fetch(EMAIL_WEBHOOK_URL, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload)
+        });
+
+        if (!response.ok) {
+            throw new Error(`Email webhook failed with status ${response.status}`);
+        }
+        return { queued: true, provider: 'webhook' };
+    }
+
+    console.info('Email queued (configure EMAIL_WEBHOOK_URL to send):', {
+        to,
+        subject,
+        text
+    });
+    return { queued: false, provider: 'console' };
+}
+
+function getSigningSecret() {
+    if (!UNSUBSCRIBE_SECRET) {
+        throw new Error('UNSUBSCRIBE_SECRET or JWT_SECRET is required for unsubscribe tokens');
+    }
+    return UNSUBSCRIBE_SECRET;
+}
+
+function signPayload(payload) {
+    return crypto.createHmac('sha256', getSigningSecret()).update(payload).digest('base64url');
+}
+
+function createUnsubscribeToken(user, scope = 'all') {
+    const payload = Buffer.from(JSON.stringify({
+        userId: String(user._id || user.id),
+        email: String(user.email || '').toLowerCase(),
+        scope,
+        version: 1
+    })).toString('base64url');
+    return `${payload}.${signPayload(payload)}`;
+}
+
+function verifyUnsubscribeToken(token) {
+    const [payload, signature] = String(token || '').split('.');
+    if (!payload || !signature) return null;
+
+    const expected = signPayload(payload);
+    const signatureBuffer = Buffer.from(signature);
+    const expectedBuffer = Buffer.from(expected);
+    if (signatureBuffer.length !== expectedBuffer.length || !crypto.timingSafeEqual(signatureBuffer, expectedBuffer)) {
+        return null;
+    }
+
+    try {
+        return JSON.parse(Buffer.from(payload, 'base64url').toString('utf8'));
+    } catch (_err) {
+        return null;
+    }
+}
+
+function buildUnsubscribeUrl(baseUrl, user, scope = 'all') {
+    const url = new URL('/api/auth', baseUrl);
+    url.searchParams.set('action', 'unsubscribe');
+    url.searchParams.set('token', createUnsubscribeToken(user, scope));
+    return url.toString();
+}
+
+function escapeHtml(value) {
+    return String(value ?? '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
+
+function listText(title, items, emptyText) {
+    if (!items.length) return `${title}: ${emptyText}`;
+    return `${title}:\n${items.map((item) => `- ${item}`).join('\n')}`;
+}
+
+function listHtml(title, items, emptyText) {
+    if (!items.length) return `<h3>${escapeHtml(title)}</h3><p>${escapeHtml(emptyText)}</p>`;
+    return `<h3>${escapeHtml(title)}</h3><ul>${items.map((item) => `<li>${escapeHtml(item)}</li>`).join('')}</ul>`;
+}
+
+async function getLatestRankChanges() {
+    const snapshots = await RankHistory.find({}).sort({ date: -1 }).limit(2).lean();
+    if (snapshots.length < 2) return [];
+
+    const [latest, previous] = snapshots;
+    const previousByAnimal = new Map((previous.rankings || []).map((ranking) => [ranking.animalName, ranking]));
+    return (latest.rankings || [])
+        .map((ranking) => {
+            const oldRanking = previousByAnimal.get(ranking.animalName);
+            if (!oldRanking) return null;
+            const delta = oldRanking.rank - ranking.rank;
+            if (!delta) return null;
+            return `${ranking.animalName} moved ${delta > 0 ? 'up' : 'down'} ${Math.abs(delta)} spot${Math.abs(delta) === 1 ? '' : 's'} to #${ranking.rank}`;
+        })
+        .filter(Boolean)
+        .slice(0, 5);
+}
+
+async function buildWeeklyDigest(user, { baseUrl } = {}) {
+    const since = new Date(Date.now() - DIGEST_LOOKBACK_DAYS * 24 * 60 * 60 * 1000);
+    const [newAnimals, topBattles, replies, rankChanges, recentCommunity] = await Promise.all([
+        Animal.find({ createdAt: { $gte: since } }).sort({ createdAt: -1 }).limit(5).lean(),
+        BattleStats.find({}).sort({ battleRating: -1, tournamentWins: -1 }).limit(5).lean(),
+        Comment.find({ parentAuthorUsername: user.username, authorId: { $ne: user._id }, createdAt: { $gte: since }, isHidden: false })
+            .sort({ createdAt: -1 })
+            .limit(5)
+            .lean(),
+        getLatestRankChanges(),
+        Comment.find({ createdAt: { $gte: since }, isHidden: false }).sort({ voteScore: -1, createdAt: -1 }).limit(5).lean()
+    ]);
+
+    const newAnimalItems = newAnimals.map((animal) => `${animal.name} joined the roster`);
+    const battleItems = topBattles.map((battle, index) => `#${index + 1} ${battle.animalName}: ${battle.battleRating} rating, ${battle.tournamentWins} tournament wins`);
+    const replyItems = replies.map((reply) => `${reply.authorUsername} replied on ${reply.animalName || reply.comparisonKey || 'a discussion'}: "${String(reply.content || '').slice(0, 90)}${String(reply.content || '').length > 90 ? '…' : ''}"`);
+    const xpSummary = `Level ${user.level || 1}, ${user.xp || 0} current XP, ${user.lifetimeXp || 0} lifetime XP, and ${user.battlePoints || 0} Battle Points.`;
+    const communityItems = recentCommunity.map((comment) => `${comment.authorUsername} posted on ${comment.animalName || comment.comparisonKey || 'the community'} (${comment.voteScore || 0} votes)`);
+
+    const sections = [
+        ['New animals', newAnimalItems, 'No new animals were added this week.'],
+        ['Top battles and ranking changes', [...battleItems, ...rankChanges].slice(0, 8), 'Battle rankings were steady this week.'],
+        ['Replies to you', replyItems, 'No new replies this week.'],
+        ['Featured tournament and community activity', communityItems, 'No featured community activity yet.']
+    ];
+
+    const unsubscribeUrl = baseUrl ? buildUnsubscribeUrl(baseUrl, user, 'all') : null;
+    const text = [
+        `Your Animal Battle Stats weekly digest, ${user.displayName || user.username}!`,
+        '',
+        ...sections.flatMap(([title, items, empty]) => [listText(title, items, empty), '']),
+        `XP/Battle Points summary: ${xpSummary}`,
+        unsubscribeUrl ? `Unsubscribe: ${unsubscribeUrl}` : ''
+    ].filter(Boolean).join('\n');
+
+    const html = `
+        <h2>Your Animal Battle Stats weekly digest</h2>
+        <p>Hi ${escapeHtml(user.displayName || user.username)}, here is what happened this week.</p>
+        ${sections.map(([title, items, empty]) => listHtml(title, items, empty)).join('')}
+        <h3>XP/Battle Points summary</h3>
+        <p>${escapeHtml(xpSummary)}</p>
+        ${unsubscribeUrl ? `<p><a href="${escapeHtml(unsubscribeUrl)}">Unsubscribe from notification emails</a></p>` : ''}
+    `;
+
+    return {
+        subject: 'Your weekly Animal Battle Stats digest',
+        text,
+        html,
+        summary: {
+            newAnimals: newAnimalItems.length,
+            topBattles: battleItems.length,
+            rankingChanges: rankChanges.length,
+            replies: replyItems.length,
+            communityActivity: communityItems.length
+        }
+    };
+}
+
+async function sendWeeklyDigest(user, options = {}) {
+    if (!preferencesAllowEmail(user, 'weeklyDigest')) {
+        return { skipped: true, reason: 'weeklyDigest disabled' };
+    }
+
+    const digest = await buildWeeklyDigest(user, options);
+    const unsubscribeUrl = options.baseUrl ? buildUnsubscribeUrl(options.baseUrl, user, 'all') : null;
+    return sendEmail({
+        to: user.email,
+        subject: digest.subject,
+        text: digest.text,
+        html: digest.html,
+        headers: unsubscribeUrl ? { 'List-Unsubscribe': `<${unsubscribeUrl}>` } : {}
+    });
+}
+
+module.exports = {
+    buildUnsubscribeUrl,
+    buildWeeklyDigest,
+    createUnsubscribeToken,
+    getDefaultNotificationPreferences,
+    normalizeNotificationPreferences,
+    preferencesAllowEmail,
+    sendEmail,
+    sendWeeklyDigest,
+    verifyUnsubscribeToken
+};

--- a/lib/models/User.js
+++ b/lib/models/User.js
@@ -6,6 +6,34 @@
 const mongoose = require('mongoose');
 const bcrypt = require('bcryptjs');
 
+
+const EmailNotificationsSchema = new mongoose.Schema({
+    enabled: {
+        type: Boolean,
+        default: false
+    },
+    weeklyDigest: {
+        type: Boolean,
+        default: false
+    },
+    newFeatures: {
+        type: Boolean,
+        default: false
+    },
+    commentReplies: {
+        type: Boolean,
+        default: false
+    },
+    tournamentUpdates: {
+        type: Boolean,
+        default: false
+    },
+    unsubscribedAt: {
+        type: Date,
+        default: null
+    }
+}, { _id: false });
+
 const AuthProviderSchema = new mongoose.Schema({
     provider: {
         type: String,
@@ -77,6 +105,10 @@ const UserSchema = new mongoose.Schema({
     authProviders: {
         type: [AuthProviderSchema],
         default: []
+    },
+    emailNotifications: {
+        type: EmailNotificationsSchema,
+        default: () => ({})
     },
     emailVerificationTokenHash: {
         type: String,


### PR DESCRIPTION
### Motivation
- Provide users with configurable email notification preferences and a weekly digest to improve engagement and surface new animals, ranking changes, replies, XP/BP summaries, and tournament/community highlights.
- Offer a simple, provider-agnostic email integration and a signed public unsubscribe flow so emails can be delivered via webhook (or swapped to a real provider) while supporting safe unsubscribe links.

### Description
- Add `emailNotifications` schema to `lib/models/User.js` with fields `enabled`, `weeklyDigest`, `newFeatures`, `commentReplies`, `tournamentUpdates`, and `unsubscribedAt` for persisted user preferences.
- Introduce `lib/email.js` implementing a webhook/console `sendEmail` provider, preference normalization helpers, signed unsubscribe token creation/verification, and `buildWeeklyDigest`/`sendWeeklyDigest` functions that summarize new animals, top battles/ranking changes, replies to the user, XP/BP, and featured tournament/community activity.
- Extend `api/auth.js` to include `GET /api/auth?action=notification-preferences` and `PUT /api/auth?action=notification-preferences` for authenticated preference management and a public `GET /api/auth?action=unsubscribe` handler that accepts a signed token and marks a user unsubscribed.
- Wire preferences into auth/profile payloads and replace local auth email helper usage with the new `sendEmail` helper in `api/auth.js` so verification/reset messages go through the same provider abstraction.
- Add profile UI controls in `index.html` and client logic in `js/auth.js` to load, edit, enable/disable, and save notification categories from the authenticated profile page, including client-side state and save flows (`fetch` calls to the new endpoints).

### Testing
- Ran a token/preference smoke check with `JWT_SECRET=test-secret node` that created and verified an unsubscribe token and exercised preference normalization, which passed.
- Performed static/parse checks: `node -c api/auth.js && node -c js/auth.js && node -c lib/email.js && node -c lib/models/User.js`, all succeeded (no syntax errors).
- Ran lint with `npm run lint` which completed without blocking errors in this change set.
- Attempted to capture a UI screenshot using Playwright (`npx playwright install chromium`), but browser downloads failed with HTTP 403 in this environment so automated browser-based screenshot tests were not completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0053c05484832097dd6e902e4721be)