### PR TITLE
Add shared CORS handling for API routes

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -97,6 +97,9 @@ npm install
    # Edit .env.local and add your credentials
    MONGODB_URI=mongodb+srv://your_username:your_password@cluster.mongodb.net/animal-stats?retryWrites=true&w=majority
    JWT_SECRET=your-secret-key-here
+   SITE_ORIGIN=https://animalbattlestats.com
+   # Optional: comma-separated exact preview origins that can call credentialed APIs
+   VERCEL_PREVIEW_ORIGINS=https://your-preview.vercel.app
    ```
 
 ### Step 4: Seed the Database
@@ -243,6 +246,10 @@ Defines:
 |----------|----------|-------------|
 | `MONGODB_URI` | Yes | MongoDB connection string |
 | `JWT_SECRET` | Yes | Secret key for JWT authentication |
+| `SITE_ORIGIN` | Yes | Canonical browser origin allowed for credentialed/auth APIs (for example, `https://animalbattlestats.com`) |
+| `CORS_ALLOWED_ORIGINS` | No | Comma-separated additional exact origins allowed for credentialed APIs |
+| `VERCEL_PREVIEW_ORIGINS` | No | Comma-separated exact Vercel preview origins allowed for credentialed APIs |
+| `ALLOW_VERCEL_PREVIEW_ORIGINS` | No | Set to `true` only when every `*.vercel.app` preview for this project should be allowed |
 | `NODE_ENV` | No | Environment (development/production) |
 
 ### Battle Points Shop (Coming Soon)

--- a/api/animals.js
+++ b/api/animals.js
@@ -14,12 +14,13 @@ const { connectToDatabase } = require('../lib/mongodb');
 const Animal = require('../lib/models/Animal');
 const { getAuthUser } = require('../lib/auth');
 const { notifyDiscord } = require('../lib/discord');
+const { setCorsHeaders } = require('../lib/cors');
 
 module.exports = async function handler(req, res) {
-    // Set CORS headers
-    res.setHeader('Access-Control-Allow-Origin', '*');
-    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
-    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+    setCorsHeaders(req, res, {
+        methods: 'GET, POST, OPTIONS',
+        credentials: true
+    });
 
     // Handle preflight
     if (req.method === 'OPTIONS') {

--- a/api/animals/[id].js
+++ b/api/animals/[id].js
@@ -11,12 +11,13 @@ const { connectToDatabase } = require('../../lib/mongodb');
 const Animal = require('../../lib/models/Animal');
 const { getAuthUser } = require('../../lib/auth');
 const mongoose = require('mongoose');
+const { setCorsHeaders } = require('../../lib/cors');
 
 module.exports = async function handler(req, res) {
-    // Set CORS headers
-    res.setHeader('Access-Control-Allow-Origin', '*');
-    res.setHeader('Access-Control-Allow-Methods', 'GET, PUT, DELETE, OPTIONS');
-    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+    setCorsHeaders(req, res, {
+        methods: 'GET, PUT, DELETE, OPTIONS',
+        credentials: true
+    });
 
     // Handle preflight
     if (req.method === 'OPTIONS') {

--- a/api/auth.js
+++ b/api/auth.js
@@ -22,6 +22,7 @@ const jwt = require('jsonwebtoken');
 const crypto = require('crypto');
 const { notifyDiscord } = require('../lib/discord');
 const { verifyToken, JWT_SECRET } = require('../lib/auth');
+const { setCorsHeaders } = require('../lib/cors');
 const { validatePublicName } = require('../lib/moderation');
 const {
     normalizeNotificationPreferences,
@@ -266,11 +267,11 @@ function buildUserPayload(user) {
 
 
 module.exports = async function handler(req, res) {
-    // Set CORS headers
-    res.setHeader('Access-Control-Allow-Origin', req.headers.origin || '*');
-    res.setHeader('Access-Control-Allow-Credentials', 'true');
-    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, OPTIONS');
-    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+    setCorsHeaders(req, res, {
+        methods: 'GET, POST, PUT, OPTIONS',
+        headers: 'Content-Type, Authorization',
+        credentials: true
+    });
 
     if (req.method === 'OPTIONS') {
         return res.status(200).end();

--- a/api/battles.js
+++ b/api/battles.js
@@ -15,6 +15,7 @@ const BattleStats = require('../lib/models/BattleStats');
 const { verifyToken: _verifyToken } = require('../lib/auth');
 const { notifyDiscord } = require('../lib/discord');
 const mongoose = require('mongoose');
+const { setCorsHeaders } = require('../lib/cors');
 
 // ELO K-factor (how much ratings change per battle)
 const K_FACTOR = 20;
@@ -45,9 +46,10 @@ function generateMatchupKey(animal1, animal2) {
 }
 
 module.exports = async function handler(req, res) {
-    res.setHeader('Access-Control-Allow-Origin', '*');
-    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
-    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+    setCorsHeaders(req, res, {
+        methods: 'GET, POST, OPTIONS',
+        credentials: true
+    });
     res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate');
 
     if (req.method === 'OPTIONS') {

--- a/api/chat.js
+++ b/api/chat.js
@@ -17,11 +17,13 @@ const Animal = require('../lib/models/Animal');
 const { verifyToken } = require('../lib/auth');
 const { notifyDiscord } = require('../lib/discord');
 const { maskBlockedTerms } = require('../lib/moderation');
+const { setCorsHeaders } = require('../lib/cors');
 
 module.exports = async function handler(req, res) {
-    res.setHeader('Access-Control-Allow-Origin', '*');
-    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PATCH, DELETE, OPTIONS');
-    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+    setCorsHeaders(req, res, {
+        methods: 'GET, POST, PATCH, DELETE, OPTIONS',
+        credentials: true
+    });
     res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate');
 
     if (req.method === 'OPTIONS') {

--- a/api/comments.js
+++ b/api/comments.js
@@ -8,11 +8,13 @@ const Comment = require('../lib/models/Comment');
 const { verifyToken } = require('../lib/auth');
 const { notifyDiscord } = require('../lib/discord');
 const { maskBlockedTerms } = require('../lib/moderation');
+const { setCorsHeaders } = require('../lib/cors');
 
 module.exports = async function handler(req, res) {
-    res.setHeader('Access-Control-Allow-Origin', '*');
-    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PATCH, DELETE, OPTIONS');
-    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+    setCorsHeaders(req, res, {
+        methods: 'GET, POST, PATCH, DELETE, OPTIONS',
+        credentials: true
+    });
     res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate');
 
     if (req.method === 'OPTIONS') {

--- a/api/community.js
+++ b/api/community.js
@@ -11,6 +11,7 @@
 
 const { connectToDatabase } = require('../lib/mongodb');
 const { verifyToken } = require('../lib/auth');
+const { setCorsHeaders } = require('../lib/cors');
 
 // In-memory presence store with TTL (would use Redis in production)
 // Structure: { odId: { username, displayName, profileAnimal, lastSeen, page } }
@@ -134,9 +135,10 @@ function cleanPageBuckets(items, limit = 8) {
 }
 
 module.exports = async function handler(req, res) {
-    res.setHeader('Access-Control-Allow-Origin', '*');
-    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
-    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+    setCorsHeaders(req, res, {
+        methods: 'GET, POST, OPTIONS',
+        credentials: true
+    });
     res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate');
 
     if (req.method === 'OPTIONS') {

--- a/api/random.js
+++ b/api/random.js
@@ -6,12 +6,15 @@
 
 const { connectToDatabase } = require('../lib/mongodb');
 const Animal = require('../lib/models/Animal');
+const { setCorsHeaders } = require('../lib/cors');
 
 module.exports = async function handler(req, res) {
-    // Set CORS headers
-    res.setHeader('Access-Control-Allow-Origin', '*');
-    res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS');
-    res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+    // Public random-animal data is read-only and returns no auth/user data, so it intentionally stays open.
+    setCorsHeaders(req, res, {
+        methods: 'GET, OPTIONS',
+        headers: 'Content-Type',
+        open: true
+    });
 
     // Handle preflight
     if (req.method === 'OPTIONS') {

--- a/api/rankings.js
+++ b/api/rankings.js
@@ -15,11 +15,13 @@ const Animal = require('../lib/models/Animal');
 const BattleStats = require('../lib/models/BattleStats');
 const RankHistory = require('../lib/models/RankHistory');
 const { notifyDiscord } = require('../lib/discord');
+const { setCorsHeaders } = require('../lib/cors');
 
 module.exports = async function handler(req, res) {
-    res.setHeader('Access-Control-Allow-Origin', '*');
-    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
-    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+    setCorsHeaders(req, res, {
+        methods: 'GET, POST, OPTIONS',
+        credentials: true
+    });
     res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate');
 
     if (req.method === 'OPTIONS') {

--- a/api/search.js
+++ b/api/search.js
@@ -6,12 +6,15 @@
 
 const { connectToDatabase } = require('../lib/mongodb');
 const Animal = require('../lib/models/Animal');
+const { setCorsHeaders } = require('../lib/cors');
 
 module.exports = async function handler(req, res) {
-    // Set CORS headers
-    res.setHeader('Access-Control-Allow-Origin', '*');
-    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
-    res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+    // Public animal search is read-only and returns no auth/user data, so it intentionally stays open.
+    setCorsHeaders(req, res, {
+        methods: 'GET, POST, OPTIONS',
+        headers: 'Content-Type',
+        open: true
+    });
 
     // Handle preflight
     if (req.method === 'OPTIONS') {

--- a/api/stats.js
+++ b/api/stats.js
@@ -9,12 +9,15 @@
 
 const { connectToDatabase } = require('../lib/mongodb');
 const Animal = require('../lib/models/Animal');
+const { setCorsHeaders } = require('../lib/cors');
 
 module.exports = async function handler(req, res) {
-    // Set CORS headers
-    res.setHeader('Access-Control-Allow-Origin', '*');
-    res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS');
-    res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+    // Public aggregate stats are read-only and return no auth/user data, so they intentionally stay open.
+    setCorsHeaders(req, res, {
+        methods: 'GET, OPTIONS',
+        headers: 'Content-Type',
+        open: true
+    });
 
     // Handle preflight
     if (req.method === 'OPTIONS') {

--- a/api/votes.js
+++ b/api/votes.js
@@ -13,11 +13,13 @@ const Vote = require('../lib/models/Vote');
 const XpClaim = require('../lib/models/XpClaim');
 const { verifyToken } = require('../lib/auth');
 const { notifyDiscord } = require('../lib/discord');
+const { setCorsHeaders } = require('../lib/cors');
 
 module.exports = async function handler(req, res) {
-    res.setHeader('Access-Control-Allow-Origin', '*');
-    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS');
-    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+    setCorsHeaders(req, res, {
+        methods: 'GET, POST, DELETE, OPTIONS',
+        credentials: true
+    });
     res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate');
 
     if (req.method === 'OPTIONS') {

--- a/lib/cors.js
+++ b/lib/cors.js
@@ -1,0 +1,112 @@
+/**
+ * Shared CORS helpers for API routes.
+ *
+ * Restricted routes should only echo configured site origins so credentials
+ * (including HttpOnly JWT cookies) are never exposed to arbitrary origins.
+ * Public read-only routes may use open CORS when they do not return user data
+ * and do not accept credentials.
+ */
+
+const DEFAULT_SITE_ORIGIN = 'https://animalbattlestats.com';
+
+function parseOriginList(value) {
+    return String(value || '')
+        .split(',')
+        .map((origin) => origin.trim())
+        .filter(Boolean)
+        .map(normalizeOrigin)
+        .filter(Boolean);
+}
+
+function normalizeOrigin(origin) {
+    try {
+        return new URL(origin).origin;
+    } catch (_error) {
+        return null;
+    }
+}
+
+function getConfiguredOrigins() {
+    const origins = new Set([
+        normalizeOrigin(process.env.SITE_ORIGIN || DEFAULT_SITE_ORIGIN),
+        ...parseOriginList(process.env.CORS_ALLOWED_ORIGINS),
+        ...parseOriginList(process.env.VERCEL_PREVIEW_ORIGINS)
+    ].filter(Boolean));
+
+    [process.env.VERCEL_URL, process.env.VERCEL_BRANCH_URL].forEach((vercelUrl) => {
+        if (!vercelUrl) return;
+        origins.add(normalizeOrigin(`https://${vercelUrl}`));
+    });
+
+    return origins;
+}
+
+function isAllowedVercelPreview(origin) {
+    if (process.env.ALLOW_VERCEL_PREVIEW_ORIGINS !== 'true') {
+        return false;
+    }
+
+    try {
+        return new URL(origin).hostname.endsWith('.vercel.app');
+    } catch (_error) {
+        return false;
+    }
+}
+
+function getAllowedOrigin(req) {
+    const configuredOrigins = getConfiguredOrigins();
+    const primaryOrigin = normalizeOrigin(process.env.SITE_ORIGIN || DEFAULT_SITE_ORIGIN);
+    const requestOrigin = normalizeOrigin((req.headers || {}).origin);
+
+    if (!requestOrigin) {
+        return primaryOrigin;
+    }
+
+    if (configuredOrigins.has(requestOrigin) || isAllowedVercelPreview(requestOrigin)) {
+        return requestOrigin;
+    }
+
+    return primaryOrigin;
+}
+
+function appendVaryOrigin(res) {
+    const existing = res.getHeader('Vary');
+    if (!existing) {
+        res.setHeader('Vary', 'Origin');
+        return;
+    }
+
+    const values = Array.isArray(existing) ? existing.join(', ') : String(existing);
+    if (!values.split(',').map((value) => value.trim().toLowerCase()).includes('origin')) {
+        res.setHeader('Vary', `${values}, Origin`);
+    }
+}
+
+function setCorsHeaders(req, res, options = {}) {
+    const {
+        methods = 'GET, OPTIONS',
+        headers = 'Content-Type, Authorization',
+        credentials = false,
+        open = false
+    } = options;
+
+    if (open) {
+        res.setHeader('Access-Control-Allow-Origin', '*');
+    } else {
+        res.setHeader('Access-Control-Allow-Origin', getAllowedOrigin(req));
+        appendVaryOrigin(res);
+    }
+
+    if (credentials) {
+        res.setHeader('Access-Control-Allow-Credentials', 'true');
+    }
+
+    res.setHeader('Access-Control-Allow-Methods', methods);
+    res.setHeader('Access-Control-Allow-Headers', headers);
+}
+
+module.exports = {
+    setCorsHeaders,
+    getConfiguredOrigins,
+    getAllowedOrigin
+};


### PR DESCRIPTION
### Motivation
- Centralize CORS logic to avoid scattered `Access-Control-Allow-Origin: *` usage and reduce the risk of exposing credentialed auth endpoints to arbitrary origins.
- Ensure credentialed endpoints return only a configured origin and support secure cookies / `Access-Control-Allow-Credentials` when needed.
- Allow exact preview origins for Vercel previews and provide opt-in wildcard behavior for all `*.vercel.app` previews.

### Description
- Added a shared helper `lib/cors.js` that exposes `setCorsHeaders`, `getConfiguredOrigins`, and `getAllowedOrigin` and reads `SITE_ORIGIN`, `CORS_ALLOWED_ORIGINS`, `VERCEL_PREVIEW_ORIGINS`, and `ALLOW_VERCEL_PREVIEW_ORIGINS` from the environment.
- Replaced per-route wildcard CORS headers in auth/user-data routes with `setCorsHeaders(..., { credentials: true })` across `api/auth.js`, `api/comments.js`, `api/chat.js`, `api/animals.js`, `api/animals/[id].js`, `api/community.js`, `api/battles.js`, `api/rankings.js`, `api/votes.js`, and similar endpoints that return or accept user/auth data.
- Kept public read-only endpoints (e.g. `api/search.js`, `api/stats.js`, `api/random.js`) intentionally open by calling `setCorsHeaders(..., { open: true })` and documented this decision inline.
- Updated `DEPLOYMENT.md` to document the new environment variables and examples for `SITE_ORIGIN`, `CORS_ALLOWED_ORIGINS`, and `VERCEL_PREVIEW_ORIGINS`.

### Testing
- Ran `npm run lint` against `js/`, `api/`, and `lib/` and it completed without errors.
- Executed a small Node assertion script that imports `setCorsHeaders` and verified behavior for trusted origin, untrusted origin, Vercel preview origin, and `open: true` mode, and all assertions passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a005678fba083208bd78b0ce1422ad8)