### PR TITLE
Add Cache-Control headers for static assets in vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -63,17 +63,71 @@
     {
       "source": "/api/(.*)",
       "headers": [
-        { "key": "Access-Control-Allow-Origin", "value": "*" },
-        { "key": "Access-Control-Allow-Methods", "value": "GET,OPTIONS,PATCH,DELETE,POST,PUT" },
-        { "key": "Access-Control-Allow-Headers", "value": "X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version, Authorization, Stripe-Signature" }
+        {
+          "key": "Access-Control-Allow-Origin",
+          "value": "*"
+        },
+        {
+          "key": "Access-Control-Allow-Methods",
+          "value": "GET,OPTIONS,PATCH,DELETE,POST,PUT"
+        },
+        {
+          "key": "Access-Control-Allow-Headers",
+          "value": "X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version, Authorization, Stripe-Signature"
+        }
+      ]
+    },
+    {
+      "source": "/images/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    },
+    {
+      "source": "/css/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=86400"
+        }
+      ]
+    },
+    {
+      "source": "/js/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=86400"
+        }
+      ]
+    },
+    {
+      "source": "/manifest.json",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=3600"
+        }
       ]
     },
     {
       "source": "/(.*)",
       "headers": [
-        { "key": "X-Content-Type-Options", "value": "nosniff" },
-        { "key": "X-Frame-Options", "value": "DENY" },
-        { "key": "X-XSS-Protection", "value": "1; mode=block" }
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        },
+        {
+          "key": "X-XSS-Protection",
+          "value": "1; mode=block"
+        }
       ]
     }
   ],


### PR DESCRIPTION
### Motivation
- Improve client performance and reduce bandwidth by adding explicit Cache-Control policies for static assets while avoiding unsafe immutable caching for non-versioned files.

### Description
- Updated `vercel.json` to add a long-lived immutable cache for images at `/images/(.*)` with `public, max-age=31536000, immutable`.
- Added conservative one-day caching for `/css/(.*)` and `/js/(.*)` using `public, max-age=86400` to avoid stale content until filename versioning is in place.
- Added a shorter one-hour cache for `/manifest.json` using `public, max-age=3600` and placed the new asset header rules after the API CORS header and before the global security headers.

### Testing
- Validated `vercel.json` parses as JSON with a `node` check and it succeeded.
- Ran `npm run lint` (ESLint) and no lint errors were reported.
- Confirmed the new headers are present in `vercel.json` and that the file remains valid JSON and well-formed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a005eef7ac88320b5ef01cc6e8319c5)